### PR TITLE
✨ Add MCP server mode for Claude Code integration

### DIFF
--- a/pkg/cluster/discovery.go
+++ b/pkg/cluster/discovery.go
@@ -26,6 +26,7 @@ type HealthInfo struct {
 	NodesReady      string
 	APIServerStatus string
 	Message         string
+	Error           string
 }
 
 // Discoverer handles cluster discovery from multiple sources
@@ -167,6 +168,11 @@ func (d *Discoverer) buildClient(contextName string) (*kubernetes.Clientset, err
 	}
 
 	return kubernetes.NewForConfig(restConfig)
+}
+
+// CheckHealthByContext checks cluster health by context name
+func (d *Discoverer) CheckHealthByContext(contextName string) (*HealthInfo, error) {
+	return d.CheckHealth(ClusterInfo{Context: contextName})
 }
 
 // GetCurrentContext returns the current kubeconfig context name

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -1,0 +1,422 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/kubestellar/kubectl-claude/pkg/cluster"
+)
+
+const (
+	MCPVersion = "2024-11-05"
+	ServerName = "kubectl-claude"
+	ServerVersion = "0.1.0"
+)
+
+// Server implements an MCP server over stdio
+type Server struct {
+	kubeconfig string
+	discoverer *cluster.Discoverer
+	reader     *bufio.Reader
+	writer     io.Writer
+	mu         sync.Mutex
+}
+
+// JSON-RPC types
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type Response struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *Error      `json:"error,omitempty"`
+}
+
+type Error struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// MCP types
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type InitializeResult struct {
+	ProtocolVersion string       `json:"protocolVersion"`
+	Capabilities    Capabilities `json:"capabilities"`
+	ServerInfo      ServerInfo   `json:"serverInfo"`
+}
+
+type Capabilities struct {
+	Tools *ToolsCapability `json:"tools,omitempty"`
+}
+
+type ToolsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+type Tool struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	InputSchema InputSchema `json:"inputSchema"`
+}
+
+type InputSchema struct {
+	Type       string              `json:"type"`
+	Properties map[string]Property `json:"properties,omitempty"`
+	Required   []string            `json:"required,omitempty"`
+}
+
+type Property struct {
+	Type        string   `json:"type"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+	Items       *Items   `json:"items,omitempty"`
+}
+
+type Items struct {
+	Type string `json:"type"`
+}
+
+type ToolsListResult struct {
+	Tools []Tool `json:"tools"`
+}
+
+type CallToolParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+type CallToolResult struct {
+	Content []ContentBlock `json:"content"`
+	IsError bool           `json:"isError,omitempty"`
+}
+
+type ContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// NewServer creates a new MCP server
+func NewServer(kubeconfig string) *Server {
+	return &Server{
+		kubeconfig: kubeconfig,
+		discoverer: cluster.NewDiscoverer(kubeconfig),
+		reader:     bufio.NewReader(os.Stdin),
+		writer:     os.Stdout,
+	}
+}
+
+// Run starts the MCP server
+func (s *Server) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		line, err := s.reader.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("failed to read request: %w", err)
+		}
+
+		var req Request
+		if err := json.Unmarshal(line, &req); err != nil {
+			s.sendError(nil, -32700, "Parse error", nil)
+			continue
+		}
+
+		s.handleRequest(ctx, &req)
+	}
+}
+
+func (s *Server) handleRequest(ctx context.Context, req *Request) {
+	switch req.Method {
+	case "initialize":
+		s.handleInitialize(req)
+	case "initialized":
+		// No response needed for notification
+	case "tools/list":
+		s.handleToolsList(req)
+	case "tools/call":
+		s.handleToolsCall(ctx, req)
+	case "ping":
+		s.sendResult(req.ID, map[string]interface{}{})
+	default:
+		s.sendError(req.ID, -32601, fmt.Sprintf("Method not found: %s", req.Method), nil)
+	}
+}
+
+func (s *Server) handleInitialize(req *Request) {
+	result := InitializeResult{
+		ProtocolVersion: MCPVersion,
+		Capabilities: Capabilities{
+			Tools: &ToolsCapability{},
+		},
+		ServerInfo: ServerInfo{
+			Name:    ServerName,
+			Version: ServerVersion,
+		},
+	}
+	s.sendResult(req.ID, result)
+}
+
+func (s *Server) handleToolsList(req *Request) {
+	tools := []Tool{
+		{
+			Name:        "list_clusters",
+			Description: "List all discovered Kubernetes clusters from kubeconfig and KubeStellar",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"source": {
+						Type:        "string",
+						Description: "Discovery source: all, kubeconfig, or kubestellar",
+						Enum:        []string{"all", "kubeconfig", "kubestellar"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "get_cluster_health",
+			Description: "Check the health status of a Kubernetes cluster",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"cluster": {
+						Type:        "string",
+						Description: "Name of the cluster to check (uses current context if not specified)",
+					},
+				},
+			},
+		},
+		{
+			Name:        "get_pods",
+			Description: "List pods in a cluster",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"cluster": {
+						Type:        "string",
+						Description: "Cluster name (uses current context if not specified)",
+					},
+					"namespace": {
+						Type:        "string",
+						Description: "Namespace to list pods from (all namespaces if not specified)",
+					},
+					"label_selector": {
+						Type:        "string",
+						Description: "Label selector to filter pods (e.g., app=nginx)",
+					},
+				},
+			},
+		},
+		{
+			Name:        "get_deployments",
+			Description: "List deployments in a cluster",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"cluster": {
+						Type:        "string",
+						Description: "Cluster name (uses current context if not specified)",
+					},
+					"namespace": {
+						Type:        "string",
+						Description: "Namespace to list deployments from (all namespaces if not specified)",
+					},
+				},
+			},
+		},
+		{
+			Name:        "get_services",
+			Description: "List services in a cluster",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"cluster": {
+						Type:        "string",
+						Description: "Cluster name (uses current context if not specified)",
+					},
+					"namespace": {
+						Type:        "string",
+						Description: "Namespace to list services from (all namespaces if not specified)",
+					},
+				},
+			},
+		},
+		{
+			Name:        "get_nodes",
+			Description: "List nodes in a cluster",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"cluster": {
+						Type:        "string",
+						Description: "Cluster name (uses current context if not specified)",
+					},
+				},
+			},
+		},
+		{
+			Name:        "get_events",
+			Description: "Get recent events from a cluster, useful for troubleshooting",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"cluster": {
+						Type:        "string",
+						Description: "Cluster name (uses current context if not specified)",
+					},
+					"namespace": {
+						Type:        "string",
+						Description: "Namespace to get events from (all namespaces if not specified)",
+					},
+					"limit": {
+						Type:        "integer",
+						Description: "Maximum number of events to return (default 50)",
+					},
+				},
+			},
+		},
+		{
+			Name:        "describe_pod",
+			Description: "Get detailed information about a specific pod",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"cluster": {
+						Type:        "string",
+						Description: "Cluster name (uses current context if not specified)",
+					},
+					"namespace": {
+						Type:        "string",
+						Description: "Namespace of the pod",
+					},
+					"name": {
+						Type:        "string",
+						Description: "Name of the pod",
+					},
+				},
+				Required: []string{"name"},
+			},
+		},
+		{
+			Name:        "get_pod_logs",
+			Description: "Get logs from a pod",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"cluster": {
+						Type:        "string",
+						Description: "Cluster name (uses current context if not specified)",
+					},
+					"namespace": {
+						Type:        "string",
+						Description: "Namespace of the pod",
+					},
+					"name": {
+						Type:        "string",
+						Description: "Name of the pod",
+					},
+					"container": {
+						Type:        "string",
+						Description: "Container name (required if pod has multiple containers)",
+					},
+					"tail_lines": {
+						Type:        "integer",
+						Description: "Number of lines from the end to return (default 100)",
+					},
+				},
+				Required: []string{"name"},
+			},
+		},
+	}
+
+	s.sendResult(req.ID, ToolsListResult{Tools: tools})
+}
+
+func (s *Server) handleToolsCall(ctx context.Context, req *Request) {
+	var params CallToolParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.sendError(req.ID, -32602, "Invalid params", nil)
+		return
+	}
+
+	var result string
+	var isError bool
+
+	switch params.Name {
+	case "list_clusters":
+		result, isError = s.toolListClusters(params.Arguments)
+	case "get_cluster_health":
+		result, isError = s.toolGetClusterHealth(params.Arguments)
+	case "get_pods":
+		result, isError = s.toolGetPods(ctx, params.Arguments)
+	case "get_deployments":
+		result, isError = s.toolGetDeployments(ctx, params.Arguments)
+	case "get_services":
+		result, isError = s.toolGetServices(ctx, params.Arguments)
+	case "get_nodes":
+		result, isError = s.toolGetNodes(ctx, params.Arguments)
+	case "get_events":
+		result, isError = s.toolGetEvents(ctx, params.Arguments)
+	case "describe_pod":
+		result, isError = s.toolDescribePod(ctx, params.Arguments)
+	case "get_pod_logs":
+		result, isError = s.toolGetPodLogs(ctx, params.Arguments)
+	default:
+		s.sendError(req.ID, -32602, fmt.Sprintf("Unknown tool: %s", params.Name), nil)
+		return
+	}
+
+	s.sendResult(req.ID, CallToolResult{
+		Content: []ContentBlock{{Type: "text", Text: result}},
+		IsError: isError,
+	})
+}
+
+func (s *Server) sendResult(id interface{}, result interface{}) {
+	s.send(Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	})
+}
+
+func (s *Server) sendError(id interface{}, code int, message string, data interface{}) {
+	s.send(Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &Error{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	})
+}
+
+func (s *Server) send(resp Response) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, _ := json.Marshal(resp)
+	fmt.Fprintf(s.writer, "%s\n", data)
+}

--- a/pkg/mcp/server/tools.go
+++ b/pkg/mcp/server/tools.go
@@ -1,0 +1,448 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func (s *Server) toolListClusters(args map[string]interface{}) (string, bool) {
+	source := "all"
+	if v, ok := args["source"].(string); ok {
+		source = v
+	}
+
+	clusters, err := s.discoverer.DiscoverClusters(source)
+	if err != nil {
+		return fmt.Sprintf("Failed to discover clusters: %v", err), true
+	}
+
+	if len(clusters) == 0 {
+		return "No clusters found", false
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Discovered clusters:\n\n")
+
+	for _, c := range clusters {
+		current := ""
+		if c.Current {
+			current = " (current)"
+		}
+		sb.WriteString(fmt.Sprintf("- %s%s\n", c.Name, current))
+		sb.WriteString(fmt.Sprintf("  Source: %s\n", c.Source))
+		sb.WriteString(fmt.Sprintf("  Server: %s\n", c.Server))
+		if c.Status != "" {
+			sb.WriteString(fmt.Sprintf("  Status: %s\n", c.Status))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String(), false
+}
+
+func (s *Server) toolGetClusterHealth(args map[string]interface{}) (string, bool) {
+	clusterName, _ := args["cluster"].(string)
+
+	clusters, err := s.discoverer.DiscoverClusters("all")
+	if err != nil {
+		return fmt.Sprintf("Failed to discover clusters: %v", err), true
+	}
+
+	var targetCluster *struct {
+		Name    string
+		Context string
+		Server  string
+		Current bool
+	}
+
+	for _, c := range clusters {
+		if clusterName == "" && c.Current {
+			targetCluster = &struct {
+				Name    string
+				Context string
+				Server  string
+				Current bool
+			}{c.Name, c.Context, c.Server, c.Current}
+			break
+		}
+		if c.Name == clusterName || c.Context == clusterName {
+			targetCluster = &struct {
+				Name    string
+				Context string
+				Server  string
+				Current bool
+			}{c.Name, c.Context, c.Server, c.Current}
+			break
+		}
+	}
+
+	if targetCluster == nil {
+		if clusterName == "" {
+			return "No current cluster context set", true
+		}
+		return fmt.Sprintf("Cluster %q not found", clusterName), true
+	}
+
+	// Check health
+	health, err := s.discoverer.CheckHealthByContext(targetCluster.Context)
+	if err != nil {
+		return fmt.Sprintf("Failed to check health: %v", err), true
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Cluster: %s\n", targetCluster.Name))
+	sb.WriteString(fmt.Sprintf("Status: %s\n", health.Status))
+	sb.WriteString(fmt.Sprintf("API Server: %s\n", health.APIServerStatus))
+	sb.WriteString(fmt.Sprintf("Nodes Ready: %s\n", health.NodesReady))
+	if health.Error != "" {
+		sb.WriteString(fmt.Sprintf("Error: %s\n", health.Error))
+	}
+
+	return sb.String(), false
+}
+
+func (s *Server) getClientForCluster(clusterName string) (*kubernetes.Clientset, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if s.kubeconfig != "" {
+		loadingRules.ExplicitPath = s.kubeconfig
+	}
+
+	configOverrides := &clientcmd.ConfigOverrides{}
+	if clusterName != "" {
+		configOverrides.CurrentContext = clusterName
+	}
+
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules, configOverrides).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return kubernetes.NewForConfig(config)
+}
+
+func (s *Server) toolGetPods(ctx context.Context, args map[string]interface{}) (string, bool) {
+	cluster, _ := args["cluster"].(string)
+	namespace, _ := args["namespace"].(string)
+	labelSelector, _ := args["label_selector"].(string)
+
+	client, err := s.getClientForCluster(cluster)
+	if err != nil {
+		return fmt.Sprintf("Failed to create client: %v", err), true
+	}
+
+	listOpts := metav1.ListOptions{}
+	if labelSelector != "" {
+		listOpts.LabelSelector = labelSelector
+	}
+
+	var pods *corev1.PodList
+	if namespace == "" {
+		pods, err = client.CoreV1().Pods("").List(ctx, listOpts)
+	} else {
+		pods, err = client.CoreV1().Pods(namespace).List(ctx, listOpts)
+	}
+
+	if err != nil {
+		return fmt.Sprintf("Failed to list pods: %v", err), true
+	}
+
+	if len(pods.Items) == 0 {
+		return "No pods found", false
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d pods:\n\n", len(pods.Items)))
+
+	for _, pod := range pods.Items {
+		status := string(pod.Status.Phase)
+		ready := 0
+		total := len(pod.Status.ContainerStatuses)
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Ready {
+				ready++
+			}
+		}
+
+		sb.WriteString(fmt.Sprintf("%-50s %-12s %d/%d   %s\n",
+			pod.Namespace+"/"+pod.Name,
+			status,
+			ready, total,
+			pod.Status.StartTime.Format("2006-01-02 15:04:05")))
+	}
+
+	return sb.String(), false
+}
+
+func (s *Server) toolGetDeployments(ctx context.Context, args map[string]interface{}) (string, bool) {
+	cluster, _ := args["cluster"].(string)
+	namespace, _ := args["namespace"].(string)
+
+	client, err := s.getClientForCluster(cluster)
+	if err != nil {
+		return fmt.Sprintf("Failed to create client: %v", err), true
+	}
+
+	var deployments interface{}
+	if namespace == "" {
+		deployments, err = client.AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
+	} else {
+		deployments, err = client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	}
+
+	if err != nil {
+		return fmt.Sprintf("Failed to list deployments: %v", err), true
+	}
+
+	data, _ := json.MarshalIndent(deployments, "", "  ")
+	return string(data), false
+}
+
+func (s *Server) toolGetServices(ctx context.Context, args map[string]interface{}) (string, bool) {
+	cluster, _ := args["cluster"].(string)
+	namespace, _ := args["namespace"].(string)
+
+	client, err := s.getClientForCluster(cluster)
+	if err != nil {
+		return fmt.Sprintf("Failed to create client: %v", err), true
+	}
+
+	var services *corev1.ServiceList
+	if namespace == "" {
+		services, err = client.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	} else {
+		services, err = client.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+	}
+
+	if err != nil {
+		return fmt.Sprintf("Failed to list services: %v", err), true
+	}
+
+	if len(services.Items) == 0 {
+		return "No services found", false
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d services:\n\n", len(services.Items)))
+
+	for _, svc := range services.Items {
+		sb.WriteString(fmt.Sprintf("%-40s %-15s %-20s %s\n",
+			svc.Namespace+"/"+svc.Name,
+			string(svc.Spec.Type),
+			svc.Spec.ClusterIP,
+			formatPorts(svc.Spec.Ports)))
+	}
+
+	return sb.String(), false
+}
+
+func formatPorts(ports []corev1.ServicePort) string {
+	var parts []string
+	for _, p := range ports {
+		if p.NodePort > 0 {
+			parts = append(parts, fmt.Sprintf("%d:%d/%s", p.Port, p.NodePort, p.Protocol))
+		} else {
+			parts = append(parts, fmt.Sprintf("%d/%s", p.Port, p.Protocol))
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+func (s *Server) toolGetNodes(ctx context.Context, args map[string]interface{}) (string, bool) {
+	cluster, _ := args["cluster"].(string)
+
+	client, err := s.getClientForCluster(cluster)
+	if err != nil {
+		return fmt.Sprintf("Failed to create client: %v", err), true
+	}
+
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("Failed to list nodes: %v", err), true
+	}
+
+	if len(nodes.Items) == 0 {
+		return "No nodes found", false
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d nodes:\n\n", len(nodes.Items)))
+
+	for _, node := range nodes.Items {
+		status := "NotReady"
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+				status = "Ready"
+				break
+			}
+		}
+
+		roles := []string{}
+		for label := range node.Labels {
+			if strings.HasPrefix(label, "node-role.kubernetes.io/") {
+				role := strings.TrimPrefix(label, "node-role.kubernetes.io/")
+				if role != "" {
+					roles = append(roles, role)
+				}
+			}
+		}
+		roleStr := strings.Join(roles, ",")
+		if roleStr == "" {
+			roleStr = "<none>"
+		}
+
+		sb.WriteString(fmt.Sprintf("%-40s %-10s %-20s %s\n",
+			node.Name,
+			status,
+			roleStr,
+			node.Status.NodeInfo.KubeletVersion))
+	}
+
+	return sb.String(), false
+}
+
+func (s *Server) toolGetEvents(ctx context.Context, args map[string]interface{}) (string, bool) {
+	cluster, _ := args["cluster"].(string)
+	namespace, _ := args["namespace"].(string)
+	limit := int64(50)
+	if v, ok := args["limit"].(float64); ok {
+		limit = int64(v)
+	}
+
+	client, err := s.getClientForCluster(cluster)
+	if err != nil {
+		return fmt.Sprintf("Failed to create client: %v", err), true
+	}
+
+	listOpts := metav1.ListOptions{
+		Limit: limit,
+	}
+
+	var events *corev1.EventList
+	if namespace == "" {
+		events, err = client.CoreV1().Events("").List(ctx, listOpts)
+	} else {
+		events, err = client.CoreV1().Events(namespace).List(ctx, listOpts)
+	}
+
+	if err != nil {
+		return fmt.Sprintf("Failed to list events: %v", err), true
+	}
+
+	if len(events.Items) == 0 {
+		return "No events found", false
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d events:\n\n", len(events.Items)))
+
+	for _, event := range events.Items {
+		sb.WriteString(fmt.Sprintf("[%s] %s/%s: %s\n",
+			event.Type,
+			event.InvolvedObject.Kind,
+			event.InvolvedObject.Name,
+			event.Message))
+	}
+
+	return sb.String(), false
+}
+
+func (s *Server) toolDescribePod(ctx context.Context, args map[string]interface{}) (string, bool) {
+	cluster, _ := args["cluster"].(string)
+	namespace, _ := args["namespace"].(string)
+	name, ok := args["name"].(string)
+	if !ok || name == "" {
+		return "Pod name is required", true
+	}
+
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	client, err := s.getClientForCluster(cluster)
+	if err != nil {
+		return fmt.Sprintf("Failed to create client: %v", err), true
+	}
+
+	pod, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("Failed to get pod: %v", err), true
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Name: %s\n", pod.Name))
+	sb.WriteString(fmt.Sprintf("Namespace: %s\n", pod.Namespace))
+	sb.WriteString(fmt.Sprintf("Status: %s\n", pod.Status.Phase))
+	sb.WriteString(fmt.Sprintf("Node: %s\n", pod.Spec.NodeName))
+	sb.WriteString(fmt.Sprintf("IP: %s\n", pod.Status.PodIP))
+
+	if pod.Status.StartTime != nil {
+		sb.WriteString(fmt.Sprintf("Start Time: %s\n", pod.Status.StartTime.Format("2006-01-02 15:04:05")))
+	}
+
+	sb.WriteString("\nContainers:\n")
+	for _, container := range pod.Spec.Containers {
+		sb.WriteString(fmt.Sprintf("  - %s (image: %s)\n", container.Name, container.Image))
+	}
+
+	sb.WriteString("\nContainer Statuses:\n")
+	for _, cs := range pod.Status.ContainerStatuses {
+		ready := "not ready"
+		if cs.Ready {
+			ready = "ready"
+		}
+		sb.WriteString(fmt.Sprintf("  - %s: %s, restarts: %d\n", cs.Name, ready, cs.RestartCount))
+	}
+
+	sb.WriteString("\nConditions:\n")
+	for _, cond := range pod.Status.Conditions {
+		sb.WriteString(fmt.Sprintf("  - %s: %s\n", cond.Type, cond.Status))
+	}
+
+	return sb.String(), false
+}
+
+func (s *Server) toolGetPodLogs(ctx context.Context, args map[string]interface{}) (string, bool) {
+	cluster, _ := args["cluster"].(string)
+	namespace, _ := args["namespace"].(string)
+	name, ok := args["name"].(string)
+	if !ok || name == "" {
+		return "Pod name is required", true
+	}
+	container, _ := args["container"].(string)
+	tailLines := int64(100)
+	if v, ok := args["tail_lines"].(float64); ok {
+		tailLines = int64(v)
+	}
+
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	client, err := s.getClientForCluster(cluster)
+	if err != nil {
+		return fmt.Sprintf("Failed to create client: %v", err), true
+	}
+
+	opts := &corev1.PodLogOptions{
+		TailLines: &tailLines,
+	}
+	if container != "" {
+		opts.Container = container
+	}
+
+	req := client.CoreV1().Pods(namespace).GetLogs(name, opts)
+	logs, err := req.DoRaw(ctx)
+	if err != nil {
+		return fmt.Sprintf("Failed to get logs: %v", err), true
+	}
+
+	return string(logs), false
+}


### PR DESCRIPTION
## Summary
- Implements MCP (Model Context Protocol) server mode for Claude Code integration
- Adds `--mcp-server` flag to run as MCP server over stdio
- Exposes 9 Kubernetes tools for multi-cluster management

## Tools exposed
- `list_clusters` - Discover clusters from kubeconfig
- `get_cluster_health` - Check cluster health status
- `get_pods`, `get_deployments`, `get_services`, `get_nodes` - List resources
- `get_events` - Get recent events for troubleshooting
- `describe_pod` - Get detailed pod information
- `get_pod_logs` - Retrieve pod logs

## Usage
```bash
# Run as MCP server (for Claude Code)
kubectl-claude --mcp-server
```

## Claude Code configuration
Add to your Claude Code settings:
```json
{
  "mcpServers": {
    "kubectl-claude": {
      "command": "kubectl-claude",
      "args": ["--mcp-server"]
    }
  }
}
```

## Test plan
- [ ] Build passes
- [ ] Unit tests pass
- [ ] Manual: `kubectl-claude --mcp-server` responds to MCP protocol
- [ ] Manual: Claude Code can discover and use the tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)