### PR TITLE
🌱 Add Homebrew tap publishing to GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,3 +49,18 @@ release:
     name: kubectl-claude
   draft: false
   prerelease: auto
+
+brews:
+  - name: kubectl-claude
+    repository:
+      owner: kubestellar
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/kubestellar/kubectl-claude"
+    description: "AI-powered multi-cluster Kubernetes management for Claude Code"
+    license: "Apache-2.0"
+    install: |
+      bin.install "kubectl-claude"
+    test: |
+      system "#{bin}/kubectl-claude", "version"


### PR DESCRIPTION
## Summary
Configures GoReleaser to automatically update the Homebrew formula in kubestellar/homebrew-tap when releases are published.

## Setup Required
Add `HOMEBREW_TAP_TOKEN` secret to the repository - a GitHub PAT with `repo` scope for kubestellar/homebrew-tap.

## Installation (after first release)
```bash
brew tap kubestellar/tap
brew install kubectl-claude
```

## Related
- Homebrew tap: https://github.com/kubestellar/homebrew-tap
- Claude plugins: https://github.com/kubestellar/claude-plugins

## Test plan
- [ ] CI passes
- [ ] After merge, tag v0.1.0 and verify release workflow publishes to Homebrew

🤖 Generated with [Claude Code](https://claude.com/claude-code)