### PR TITLE
✨ Add audit_clusters tool for kubeconfig cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Once installed, ask questions like:
 | `list_clusters` | Discover clusters from kubeconfig |
 | `get_cluster_health` | Check cluster health status |
 | `get_nodes` | List cluster nodes with status |
+| `audit_kubeconfig` | Audit all clusters for connectivity and recommend cleanup |
 
 ### Workload Tools
 | Tool | Description |

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -616,6 +616,19 @@ func (s *Server) handleToolsList(req *Request) {
 				},
 			},
 		},
+		{
+			Name:        "audit_kubeconfig",
+			Description: "Audit all clusters in kubeconfig: check connectivity, identify stale/inaccessible clusters, and recommend cleanup",
+			InputSchema: InputSchema{
+				Type: "object",
+				Properties: map[string]Property{
+					"timeout_seconds": {
+						Type:        "integer",
+						Description: "Connection timeout in seconds per cluster (default 5)",
+					},
+				},
+			},
+		},
 	}
 
 	s.sendResult(req.ID, ToolsListResult{Tools: tools})
@@ -676,6 +689,8 @@ func (s *Server) handleToolsCall(ctx context.Context, req *Request) {
 		result, isError = s.toolAnalyzeNamespace(ctx, params.Arguments)
 	case "get_warning_events":
 		result, isError = s.toolGetWarningEvents(ctx, params.Arguments)
+	case "audit_kubeconfig":
+		result, isError = s.toolAuditKubeconfig(ctx, params.Arguments)
 	default:
 		s.sendError(req.ID, -32602, fmt.Sprintf("Unknown tool: %s", params.Name), nil)
 		return


### PR DESCRIPTION
## Summary
- Adds `audit_clusters` tool to check connectivity to all clusters in kubeconfig
- Reports accessible clusters with their Kubernetes versions
- Reports inaccessible clusters with simplified error messages
- Provides cleanup commands to remove stale contexts, clusters, and users

## Example Output
```
# Kubeconfig Cluster Audit

**Total contexts:** 5
**Accessible:** 3
**Inaccessible:** 2

## Accessible Clusters
- **prod-cluster** **(current)**
  - Server: https://prod.example.com:6443
  - Version: v1.28.4

## Inaccessible Clusters
- **old-dev-cluster**
  - Server: https://old-dev.example.com:6443
  - Error: Connection timeout

## Cleanup Recommendations
kubectl config delete-context old-dev-cluster
```

## Test plan
- [x] Build passes
- [ ] Manual testing with kubeconfig containing accessible and inaccessible clusters

🤖 Generated with [Claude Code](https://claude.ai/code)