### PR TITLE
🌱 Add docs release automation trigger

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,20 @@
+name: Trigger Docs Update
+
+on:
+  release:
+    types: [published]
+
+# No GITHUB_TOKEN permissions needed - uses WORKFLOW_SYNC_TOKEN secret
+permissions: {}
+
+jobs:
+  trigger-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs repo
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
+        run: |
+          gh api repos/kubestellar/docs/dispatches \
+            -f event_type=create-version-branch \
+            -f client_payload="{\"project\":\"kubectl-claude\",\"version\":\"${{ github.event.release.tag_name }}\",\"source_repo\":\"${{ github.repository }}\",\"source_branch\":\"${{ github.event.release.target_commitish }}\"}"


### PR DESCRIPTION
## Summary
Adds workflow to trigger documentation updates when releases are published.

When a release is published, this workflow dispatches an event to kubestellar/docs 
to create a version branch and update the version list.

## Requirements
- `WORKFLOW_SYNC_TOKEN` secret must be configured with permissions to trigger 
  kubestellar/docs repository dispatch

🤖 Generated with [Claude Code](https://claude.ai/code)