### PR TITLE
✨ Rename kubectl-claude to klaude

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -35,7 +35,7 @@ jobs:
           {
             "event_type": "create-version-branch",
             "client_payload": {
-              "project": "kubectl-claude",
+              "project": "klaude",
               "version": "${{ steps.version.outputs.tag }}",
               "source_repo": "${{ github.repository }}",
               "source_branch": "${{ steps.version.outputs.branch }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,9 +5,9 @@ before:
     - go mod tidy
 
 builds:
-  - id: kubectl-claude
-    main: ./cmd/kubectl-claude
-    binary: kubectl-claude
+  - id: klaude
+    main: ./cmd/klaude
+    binary: klaude
     env:
       - CGO_ENABLED=0
     goos:
@@ -18,12 +18,12 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/kubestellar/kubectl-claude/internal/version.Version={{.Version}}
-      - -X github.com/kubestellar/kubectl-claude/internal/version.BuildDate={{.Date}}
-      - -X github.com/kubestellar/kubectl-claude/internal/version.GitCommit={{.Commit}}
+      - -X github.com/kubestellar/klaude/internal/version.Version={{.Version}}
+      - -X github.com/kubestellar/klaude/internal/version.BuildDate={{.Date}}
+      - -X github.com/kubestellar/klaude/internal/version.GitCommit={{.Commit}}
 
 archives:
-  - id: kubectl-claude
+  - id: klaude
     format: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
@@ -46,21 +46,21 @@ changelog:
 release:
   github:
     owner: kubestellar
-    name: kubectl-claude
+    name: klaude
   draft: false
   prerelease: auto
 
 brews:
-  - name: kubectl-claude
+  - name: klaude
     repository:
       owner: kubestellar
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
-    homepage: "https://github.com/kubestellar/kubectl-claude"
+    homepage: "https://github.com/kubestellar/klaude"
     description: "AI-powered multi-cluster Kubernetes management for Claude Code"
     license: "Apache-2.0"
     install: |
-      bin.install "kubectl-claude"
+      bin.install "klaude"
     test: |
-      system "#{bin}/kubectl-claude", "version"
+      system "#{bin}/klaude", "version"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-# kubectl-claude Makefile
+# klaude Makefile
 
-BINARY_NAME := kubectl-claude
-MODULE := github.com/kubestellar/kubectl-claude
+BINARY_NAME := klaude
+MODULE := github.com/kubestellar/klaude
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -20,21 +20,21 @@ GOARCH ?= $(shell go env GOARCH)
 all: build
 
 build:
-	CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME) ./cmd/kubectl-claude
+	CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME) ./cmd/klaude
 
 build-all: build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64
 
 build-linux-amd64:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME)-linux-amd64 ./cmd/kubectl-claude
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME)-linux-amd64 ./cmd/klaude
 
 build-linux-arm64:
-	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME)-linux-arm64 ./cmd/kubectl-claude
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME)-linux-arm64 ./cmd/klaude
 
 build-darwin-amd64:
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME)-darwin-amd64 ./cmd/kubectl-claude
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME)-darwin-amd64 ./cmd/klaude
 
 build-darwin-arm64:
-	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME)-darwin-arm64 ./cmd/kubectl-claude
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 $(GO) build -ldflags="$(LDFLAGS)" -o bin/$(BINARY_NAME)-darwin-arm64 ./cmd/klaude
 
 clean:
 	rm -rf bin/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kubectl-claude
+# klaude
 
 AI-powered kubectl plugin for multi-cluster Kubernetes management, with built-in diagnostic tools.
 
@@ -8,20 +8,20 @@ AI-powered kubectl plugin for multi-cluster Kubernetes management, with built-in
 
 ```bash
 brew tap kubestellar/tap
-brew install kubectl-claude
+brew install klaude
 ```
 
 ### From Releases
 
-Download from [GitHub Releases](https://github.com/kubestellar/kubectl-claude/releases).
+Download from [GitHub Releases](https://github.com/kubestellar/klaude/releases).
 
 ### From Source
 
 ```bash
-git clone https://github.com/kubestellar/kubectl-claude.git
-cd kubectl-claude
-go build -o kubectl-claude ./cmd/kubectl-claude
-sudo mv kubectl-claude /usr/local/bin/
+git clone https://github.com/kubestellar/klaude.git
+cd klaude
+go build -o klaude ./cmd/klaude
+sudo mv klaude /usr/local/bin/
 ```
 
 ## Claude Code Plugin
@@ -33,13 +33,13 @@ sudo mv kubectl-claude /usr/local/bin/
    /plugin marketplace add kubestellar/claude-plugins
    ```
 2. Go to `/plugin` → **Discover** tab
-3. Install **kubectl-claude**
+3. Install **klaude**
 
 ### Verify Installation
 
 Run `/mcp` in Claude Code - you should see:
 ```
-plugin:kubectl-claude:kubectl-claude · ✓ connected
+plugin:klaude:klaude · ✓ connected
 ```
 
 ### Allow Tools Without Prompts
@@ -50,7 +50,7 @@ To avoid permission prompts for each tool call, add to `~/.claude/settings.json`
 {
   "permissions": {
     "allow": [
-      "mcp__plugin_kubectl-claude_kubectl-claude__*"
+      "mcp__plugin_klaude_klaude__*"
     ]
   }
 }
@@ -58,7 +58,7 @@ To avoid permission prompts for each tool call, add to `~/.claude/settings.json`
 
 Or run in Claude Code:
 ```
-/allowed-tools add mcp__plugin_kubectl-claude_kubectl-claude__*
+/allowed-tools add mcp__plugin_klaude_klaude__*
 ```
 
 ### Usage in Claude Code
@@ -137,7 +137,7 @@ Once installed, ask questions like:
 
 ## Slash Commands
 
-When using kubectl-claude as a Claude Code plugin, these slash commands are available:
+When using klaude as a Claude Code plugin, these slash commands are available:
 
 | Command | Description |
 |---------|-------------|
@@ -157,20 +157,20 @@ When using kubectl-claude as a Claude Code plugin, these slash commands are avai
 
 ```bash
 # List all clusters
-kubectl claude clusters list
+kubectl klaude clusters list
 
 # Check cluster health
-kubectl claude clusters health
+kubectl klaude clusters health
 
 # Natural language queries (requires ANTHROPIC_API_KEY)
-kubectl claude "show me failing pods"
+kubectl klaude "show me failing pods"
 ```
 
 ### As MCP Server
 
 ```bash
 # Start MCP server (used by Claude Code)
-kubectl-claude --mcp-server
+klaude --mcp-server
 ```
 
 ## Environment Variables

--- a/cmd/klaude/main.go
+++ b/cmd/klaude/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/kubestellar/kubectl-claude/pkg/cmd"
+	"github.com/kubestellar/klaude/pkg/cmd"
 )
 
 func main() {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 ---
-title: kubectl-claude
+title: klaude
 description: AI-powered kubectl plugin for multi-cluster Kubernetes management
 ---
 
-# kubectl-claude
+# klaude
 
 AI-powered kubectl plugin for multi-cluster Kubernetes management, with built-in diagnostic tools.
 
@@ -12,13 +12,13 @@ AI-powered kubectl plugin for multi-cluster Kubernetes management, with built-in
 ```bash
 # Install via Homebrew
 brew tap kubestellar/tap
-brew install kubectl-claude
+brew install klaude
 
 # Check cluster health
-kubectl claude clusters health
+kubectl klaude clusters health
 
 # Find issues across all namespaces
-kubectl claude "show me pods with problems"
+kubectl klaude "show me pods with problems"
 ```
 
 ## Installation
@@ -27,20 +27,20 @@ kubectl claude "show me pods with problems"
 
 ```bash
 brew tap kubestellar/tap
-brew install kubectl-claude
+brew install klaude
 ```
 
 ### From Releases
 
-Download from [GitHub Releases](https://github.com/kubestellar/kubectl-claude/releases).
+Download from [GitHub Releases](https://github.com/kubestellar/klaude/releases).
 
 ### From Source
 
 ```bash
-git clone https://github.com/kubestellar/kubectl-claude.git
-cd kubectl-claude
-go build -o kubectl-claude ./cmd/kubectl-claude
-sudo mv kubectl-claude /usr/local/bin/
+git clone https://github.com/kubestellar/klaude.git
+cd klaude
+go build -o klaude ./cmd/klaude
+sudo mv klaude /usr/local/bin/
 ```
 
 ## Claude Code Plugin
@@ -52,13 +52,13 @@ sudo mv kubectl-claude /usr/local/bin/
    /plugin marketplace add kubestellar/claude-plugins
    ```
 2. Go to `/plugin` → **Discover** tab
-3. Install **kubectl-claude**
+3. Install **klaude**
 
 ### Verify Installation
 
 Run `/mcp` in Claude Code - you should see:
 ```
-plugin:kubectl-claude:kubectl-claude · ✓ connected
+plugin:klaude:klaude · ✓ connected
 ```
 
 ### Allow Tools Without Prompts
@@ -69,7 +69,7 @@ To avoid permission prompts for each tool call, add to `~/.claude/settings.json`
 {
   "permissions": {
     "allow": [
-      "mcp__plugin_kubectl-claude_kubectl-claude__*"
+      "mcp__plugin_klaude_klaude__*"
     ]
   }
 }
@@ -77,7 +77,7 @@ To avoid permission prompts for each tool call, add to `~/.claude/settings.json`
 
 Or run in Claude Code:
 ```
-/allowed-tools add mcp__plugin_kubectl-claude_kubectl-claude__*
+/allowed-tools add mcp__plugin_klaude_klaude__*
 ```
 
 ### Usage in Claude Code
@@ -91,7 +91,7 @@ Once installed, ask questions like:
 - "Show me warning events in kube-system"
 - "Analyze the default namespace"
 
-## Available Tools (30 total)
+## Available Tools (37 total)
 
 ### Cluster Management
 | Tool | Description |
@@ -143,6 +143,17 @@ Once installed, ask questions like:
 | `set_ownership_policy_mode` | Change policy enforcement mode |
 | `uninstall_ownership_policy` | Remove the ownership policy |
 
+### Upgrade Tools
+| Tool | Description |
+|------|-------------|
+| `detect_cluster_type` | Detect cluster distribution (OpenShift, EKS, GKE, AKS, kubeadm, k3s, kind) |
+| `get_cluster_version_info` | Get current version and available upgrades |
+| `check_olm_operator_upgrades` | Check OLM operators for pending upgrades |
+| `check_helm_release_upgrades` | List Helm releases and their versions |
+| `get_upgrade_prerequisites` | Validate upgrade readiness (nodes, pods, ClusterOperators) |
+| `trigger_openshift_upgrade` | Trigger OpenShift cluster upgrade (requires confirmation) |
+| `get_upgrade_status` | Monitor upgrade progress |
+
 ## Slash Commands
 
 | Command | Description |
@@ -154,6 +165,8 @@ Once installed, ask questions like:
 | `/k8s-rbac` | Analyze RBAC permissions for a subject |
 | `/k8s-audit-kubeconfig` | Audit kubeconfig clusters and recommend cleanup |
 | `/k8s-ownership` | Set up resource ownership tracking with OPA Gatekeeper |
+| `/k8s-upgrade-check` | Check for available upgrades (cluster, OLM operators, Helm releases) |
+| `/k8s-upgrade` | Interactive cluster upgrade workflow with safety checks |
 
 ## CLI Usage
 
@@ -161,20 +174,20 @@ Once installed, ask questions like:
 
 ```bash
 # List all clusters
-kubectl claude clusters list
+kubectl klaude clusters list
 
 # Check cluster health
-kubectl claude clusters health
+kubectl klaude clusters health
 
 # Natural language queries (requires ANTHROPIC_API_KEY)
-kubectl claude "show me failing pods"
+kubectl klaude "show me failing pods"
 ```
 
 ### As MCP Server
 
 ```bash
 # Start MCP server (used by Claude Code)
-kubectl-claude --mcp-server
+klaude --mcp-server
 ```
 
 ## Environment Variables
@@ -186,8 +199,8 @@ kubectl-claude --mcp-server
 
 ## Contributing
 
-Contributions are welcome! Please read our [contributing guidelines](https://github.com/kubestellar/kubectl-claude/blob/main/CONTRIBUTING.md).
+Contributions are welcome! Please read our [contributing guidelines](https://github.com/kubestellar/klaude/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Apache License 2.0 - see [LICENSE](https://github.com/kubestellar/kubectl-claude/blob/main/LICENSE) for details.
+Apache License 2.0 - see [LICENSE](https://github.com/kubestellar/klaude/blob/main/LICENSE) for details.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubestellar/kubectl-claude
+module github.com/kubestellar/klaude
 
 go 1.22.0
 
@@ -6,6 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/spf13/cobra v1.8.1
+	k8s.io/api v0.30.4
 	k8s.io/apimachinery v0.30.4
 	k8s.io/cli-runtime v0.30.4
 	k8s.io/client-go v0.30.4
@@ -57,7 +58,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.30.4 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect

--- a/pkg/cmd/ai/query.go
+++ b/pkg/cmd/ai/query.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/kubestellar/kubectl-claude/pkg/ai/claude"
-	"github.com/kubestellar/kubectl-claude/pkg/cluster"
+	"github.com/kubestellar/klaude/pkg/ai/claude"
+	"github.com/kubestellar/klaude/pkg/cluster"
 )
 
 type queryOptions struct {
@@ -40,16 +40,16 @@ The AI assistant has context about your available clusters and can help with:
 
 Examples:
   # Ask about pods
-  kubectl claude query "show me all pods that are not running"
+  kubectl klaude query "show me all pods that are not running"
 
   # Get troubleshooting help
-  kubectl claude query "why might my deployment be failing to start?"
+  kubectl klaude query "why might my deployment be failing to start?"
 
   # Get command suggestions
-  kubectl claude query "how do I scale my nginx deployment to 5 replicas?"
+  kubectl klaude query "how do I scale my nginx deployment to 5 replicas?"
 
   # Ask about cluster state
-  kubectl claude query "what's the overall health of my cluster?"`,
+  kubectl klaude query "what's the overall health of my cluster?"`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.query = strings.Join(args, " ")

--- a/pkg/cmd/clusters/health.go
+++ b/pkg/cmd/clusters/health.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/kubestellar/kubectl-claude/pkg/cluster"
+	"github.com/kubestellar/klaude/pkg/cluster"
 )
 
 type healthOptions struct {
@@ -35,13 +35,13 @@ Health checks include:
 
 Examples:
   # Check health of all clusters
-  kubectl claude clusters health --all-clusters
+  kubectl klaude clusters health --all-clusters
 
   # Check health of specific cluster
-  kubectl claude clusters health prod-east
+  kubectl klaude clusters health prod-east
 
   # Check health of current context
-  kubectl claude clusters health`,
+  kubectl klaude clusters health`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				o.clusterName = args[0]

--- a/pkg/cmd/clusters/list.go
+++ b/pkg/cmd/clusters/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/kubestellar/kubectl-claude/pkg/cluster"
+	"github.com/kubestellar/klaude/pkg/cluster"
 )
 
 type listOptions struct {
@@ -36,13 +36,13 @@ The output shows:
 
 Examples:
   # List all clusters
-  kubectl claude clusters list
+  kubectl klaude clusters list
 
   # List only kubeconfig clusters
-  kubectl claude clusters list --source=kubeconfig
+  kubectl klaude clusters list --source=kubeconfig
 
   # List only KubeStellar managed clusters
-  kubectl claude clusters list --source=kubestellar`,
+  kubectl klaude clusters list --source=kubestellar`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.run()
 		},

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -11,10 +11,10 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/kubestellar/kubectl-claude/internal/version"
-	"github.com/kubestellar/kubectl-claude/pkg/cmd/ai"
-	"github.com/kubestellar/kubectl-claude/pkg/cmd/clusters"
-	"github.com/kubestellar/kubectl-claude/pkg/mcp/server"
+	"github.com/kubestellar/klaude/internal/version"
+	"github.com/kubestellar/klaude/pkg/cmd/ai"
+	"github.com/kubestellar/klaude/pkg/cmd/clusters"
+	"github.com/kubestellar/klaude/pkg/mcp/server"
 )
 
 var (
@@ -30,9 +30,9 @@ var (
 
 // rootCmd represents the base command
 var rootCmd = &cobra.Command{
-	Use:   "kubectl-claude",
+	Use:   "klaude",
 	Short: "AI-powered kubectl plugin for multi-cluster Kubernetes management",
-	Long: `kubectl-claude is an AI-powered kubectl plugin that helps you manage
+	Long: `klaude is an AI-powered kubectl plugin that helps you manage
 clusters and deployments across multiple Kubernetes clusters.
 
 It provides intelligent assistance for:
@@ -43,16 +43,16 @@ It provides intelligent assistance for:
 
 Examples:
   # List all available clusters
-  kubectl claude clusters list
+  kubectl klaude clusters list
 
   # Ask a natural language question (shorthand)
-  kubectl claude "show me all failing pods"
+  kubectl klaude "show me all failing pods"
 
   # Ask using query subcommand
-  kubectl claude query "why is my pod crashing?"
+  kubectl klaude query "why is my pod crashing?"
 
   # Check cluster health
-  kubectl claude clusters health --all-clusters`,
+  kubectl klaude clusters health --all-clusters`,
 	Version: version.Version,
 	// Handle natural language queries directly
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -170,7 +170,7 @@ func newVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Print version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("kubectl-claude version %s\n", version.Version)
+			fmt.Printf("klaude version %s\n", version.Version)
 			fmt.Printf("  Build date: %s\n", version.BuildDate)
 			fmt.Printf("  Git commit: %s\n", version.GitCommit)
 		},

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"sync"
 
-	"github.com/kubestellar/kubectl-claude/pkg/cluster"
+	"github.com/kubestellar/klaude/pkg/cluster"
 )
 
 const (
 	MCPVersion = "2024-11-05"
-	ServerName = "kubectl-claude"
-	ServerVersion = "0.1.0"
+	ServerName = "klaude"
+	ServerVersion = "0.6.0"
 )
 
 // Server implements an MCP server over stdio


### PR DESCRIPTION
## Summary

- Renames the project from `kubectl-claude` to `klaude` - a cleaner, more memorable name
- Updates Go module path, binary name, all imports, and documentation
- The binary still works as `kubectl klaude` due to kubectl's plugin discovery

## Changes

- Rename Go module: `github.com/kubestellar/kubectl-claude` → `github.com/kubestellar/klaude`
- Rename binary: `kubectl-claude` → `klaude`
- Move `cmd/kubectl-claude/` → `cmd/klaude/`
- Update all CLI examples and documentation
- Update GoReleaser for new binary name
- MCP server identifies as `klaude` v0.6.0

## After Merging

1. **Rename GitHub repo**: Settings → Rename to `klaude` (creates automatic redirect)
2. **Update claude-plugins**: Rename plugin folder and config
3. **Create release**: Tag v0.6.0 to trigger GoReleaser

## Test plan

- [x] `go build -o klaude ./cmd/klaude` succeeds
- [x] `./klaude version` shows `klaude version dev`
- [ ] CI passes
- [ ] After repo rename: `kubectl klaude clusters list` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)