### PR TITLE
✨ Add detect_drift tool for GitOps drift detection

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -253,6 +253,11 @@ Multi-cluster Kubernetes diagnostics, RBAC analysis, and security checks.
 | `trigger_openshift_upgrade` | Trigger OpenShift cluster upgrade (requires confirmation) |
 | `get_upgrade_status` | Monitor upgrade progress |
 
+#### GitOps Tools
+| Tool | Description |
+|------|-------------|
+| `detect_drift` | Detect configuration drift between Git manifests and cluster state |
+
 ### Slash Commands
 
 | Command | Description |

--- a/pkg/gitops/drift.go
+++ b/pkg/gitops/drift.go
@@ -108,7 +108,7 @@ func (d *DriftDetector) checkResource(ctx context.Context, manifest Manifest, cl
 
 	// Get current state from cluster
 	var current *unstructured.Unstructured
-	if namespace != "" && !isClusterScoped(manifest.Kind) {
+	if namespace != "" && !IsClusterScoped(manifest.Kind) {
 		current, err = d.dynClient.Resource(gvr).Namespace(namespace).Get(ctx, manifest.Metadata.Name, metav1.GetOptions{})
 	} else {
 		current, err = d.dynClient.Resource(gvr).Get(ctx, manifest.Metadata.Name, metav1.GetOptions{})
@@ -280,8 +280,8 @@ func kindToResource(kind string) string {
 	return strings.ToLower(kind) + "s"
 }
 
-// isClusterScoped returns true if the kind is cluster-scoped
-func isClusterScoped(kind string) bool {
+// IsClusterScoped returns true if the kind is cluster-scoped
+func IsClusterScoped(kind string) bool {
 	clusterScoped := map[string]bool{
 		"Namespace":             true,
 		"Node":                  true,

--- a/pkg/gitops/sync.go
+++ b/pkg/gitops/sync.go
@@ -95,7 +95,7 @@ func (s *Syncer) Sync(ctx context.Context, manifests []Manifest, clusterName str
 
 		// Override namespace if specified
 		namespace := manifest.GetNamespace()
-		if opts.Namespace != "" && !isClusterScoped(manifest.Kind) {
+		if opts.Namespace != "" && !IsClusterScoped(manifest.Kind) {
 			namespace = opts.Namespace
 		}
 
@@ -140,7 +140,7 @@ func (s *Syncer) syncResource(ctx context.Context, manifest Manifest, namespace 
 	obj := &unstructured.Unstructured{Object: manifest.Raw}
 
 	// Set namespace if not cluster-scoped
-	if !isClusterScoped(manifest.Kind) && namespace != "" {
+	if !IsClusterScoped(manifest.Kind) && namespace != "" {
 		obj.SetNamespace(namespace)
 	}
 
@@ -152,7 +152,7 @@ func (s *Syncer) syncResource(ctx context.Context, manifest Manifest, namespace 
 
 	// Check if resource exists
 	var existing *unstructured.Unstructured
-	if isClusterScoped(manifest.Kind) {
+	if IsClusterScoped(manifest.Kind) {
 		existing, err = s.dynClient.Resource(gvr).Get(ctx, manifest.Metadata.Name, metav1.GetOptions{})
 	} else {
 		existing, err = s.dynClient.Resource(gvr).Namespace(namespace).Get(ctx, manifest.Metadata.Name, metav1.GetOptions{})
@@ -167,7 +167,7 @@ func (s *Syncer) syncResource(ctx context.Context, manifest Manifest, namespace 
 		}
 
 		var created *unstructured.Unstructured
-		if isClusterScoped(manifest.Kind) {
+		if IsClusterScoped(manifest.Kind) {
 			created, err = s.dynClient.Resource(gvr).Create(ctx, obj, metav1.CreateOptions{})
 		} else {
 			created, err = s.dynClient.Resource(gvr).Namespace(namespace).Create(ctx, obj, metav1.CreateOptions{})
@@ -196,7 +196,7 @@ func (s *Syncer) syncResource(ctx context.Context, manifest Manifest, namespace 
 	}
 
 	var updated *unstructured.Unstructured
-	if isClusterScoped(manifest.Kind) {
+	if IsClusterScoped(manifest.Kind) {
 		updated, err = s.dynClient.Resource(gvr).Patch(ctx, manifest.Metadata.Name,
 			types.ApplyPatchType, data, metav1.PatchOptions{
 				FieldManager: "klaude-deploy",


### PR DESCRIPTION
## Summary
- Add `detect_drift` MCP tool to klaude-ops for GitOps drift detection
- Export `IsClusterScoped` function from gitops package
- Enables KubeStellar Console to detect real drift instead of using kubectl diff fallback

## Changes
- `pkg/mcp/server/server.go`: Add tool definition to `handleToolsList()` and dispatcher case
- `pkg/mcp/server/tools.go`: Implement `toolDetectDrift()` handler with:
  - Git repo cloning and manifest parsing
  - Cluster state comparison using `DriftDetector`
  - Human-readable and JSON output
- `pkg/gitops/drift.go`: Export `IsClusterScoped` function
- `pkg/gitops/sync.go`: Update to use exported function

## Test plan
- [ ] Build passes (`go build ./...`)
- [ ] MCP server starts and lists detect_drift tool
- [ ] Test drift detection against a sample repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)