### PR TITLE
📖 Add label command and marketplace release automation

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -42,3 +42,14 @@ jobs:
               "source_repo": "kubestellar/klaude",
               "source_branch": "${{ github.ref_name }}"
             }
+      - name: Trigger marketplace plugin update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
+          repository: kubestellar/claude-plugins
+          event-type: update-plugin-version
+          client-payload: |
+            {
+              "version": "${{ github.ref_name }}",
+              "source_repo": "kubestellar/klaude"
+            }

--- a/commands/label.md
+++ b/commands/label.md
@@ -1,0 +1,75 @@
+# Label
+
+Add or remove labels from Kubernetes resources across clusters.
+
+## Usage
+
+Manage labels on resources across multiple clusters.
+
+## Examples
+
+- "Add label team=platform to deployment api"
+- "Label all my nginx pods with env=production"
+- "Remove the deprecated label from configmap settings"
+- "Add owner=andy to service frontend in all clusters"
+
+## What it does
+
+1. Targets specified clusters (or all available)
+2. Adds or removes labels using JSON merge patch
+3. Reports success/failure per cluster
+
+## MCP Tools Used
+
+- `add_labels` - Add labels to a resource
+- `remove_labels` - Remove labels from a resource
+
+## Supported Resource Types
+
+- Deployments, StatefulSets, DaemonSets
+- Services, ConfigMaps, Secrets
+- Pods, Namespaces, Nodes
+- PersistentVolumes, PersistentVolumeClaims
+
+## Implementation
+
+**Add labels** with the `add_labels` tool:
+- `kind`: Resource kind (required)
+- `name`: Resource name (required)
+- `namespace`: Namespace (default: default)
+- `labels`: Map of label key-values to add (required)
+- `dry_run`: Preview without applying
+- `clusters`: Target clusters (all if not specified)
+
+**Remove labels** with the `remove_labels` tool:
+- `kind`: Resource kind (required)
+- `name`: Resource name (required)
+- `namespace`: Namespace (default: default)
+- `labels`: Array of label keys to remove (required)
+- `dry_run`: Preview without applying
+- `clusters`: Target clusters (all if not specified)
+
+## Examples of Tool Calls
+
+**Add labels:**
+```json
+{
+  "kind": "Deployment",
+  "name": "api",
+  "namespace": "default",
+  "labels": {
+    "team": "platform",
+    "owner": "andy"
+  }
+}
+```
+
+**Remove labels:**
+```json
+{
+  "kind": "Deployment",
+  "name": "api",
+  "namespace": "default",
+  "labels": ["deprecated", "old-owner"]
+}
+```


### PR DESCRIPTION
## Summary
- Add missing `/label` slash command documentation
- Add automation to trigger marketplace plugin updates on release

## Changes

### Label Command
Added `commands/label.md` for the `/label` slash command which uses:
- `add_labels` - Add labels to resources
- `remove_labels` - Remove labels from resources

### Release Automation
Added `repository_dispatch` trigger in `goreleaser.yml` to automatically update the `kubestellar/claude-plugins` marketplace when a new version is released.

This requires a corresponding workflow in claude-plugins to handle the `update-plugin-version` event.

## Test plan
- [ ] Verify label.md is accessible in plugin
- [ ] Verify automation triggers on next release (requires claude-plugins workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)