### PR TITLE
⚠️ Rename: Update Go module path to kubestellar-mcp

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,9 +20,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/kubestellar/klaude/internal/version.Version={{.Version}}
-      - -X github.com/kubestellar/klaude/internal/version.BuildDate={{.Date}}
-      - -X github.com/kubestellar/klaude/internal/version.GitCommit={{.Commit}}
+      - -X github.com/kubestellar/kubestellar-mcp/internal/version.Version={{.Version}}
+      - -X github.com/kubestellar/kubestellar-mcp/internal/version.BuildDate={{.Date}}
+      - -X github.com/kubestellar/kubestellar-mcp/internal/version.GitCommit={{.Commit}}
 
   - id: kubestellar-deploy
     main: ./cmd/kubestellar-deploy
@@ -37,9 +37,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/kubestellar/klaude/internal/version.Version={{.Version}}
-      - -X github.com/kubestellar/klaude/internal/version.BuildDate={{.Date}}
-      - -X github.com/kubestellar/klaude/internal/version.GitCommit={{.Commit}}
+      - -X github.com/kubestellar/kubestellar-mcp/internal/version.Version={{.Version}}
+      - -X github.com/kubestellar/kubestellar-mcp/internal/version.BuildDate={{.Date}}
+      - -X github.com/kubestellar/kubestellar-mcp/internal/version.GitCommit={{.Commit}}
 
 archives:
   - id: kubestellar-ops
@@ -73,7 +73,7 @@ changelog:
 release:
   github:
     owner: kubestellar
-    name: klaude
+    name: kubestellar-mcp
   draft: false
   prerelease: auto
 
@@ -86,7 +86,7 @@ brews:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
-    homepage: "https://github.com/kubestellar/klaude"
+    homepage: "https://github.com/kubestellar/kubestellar-mcp"
     description: "Multi-cluster Kubernetes diagnostics, RBAC analysis, and security checks"
     license: "Apache-2.0"
     install: |
@@ -102,7 +102,7 @@ brews:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
-    homepage: "https://github.com/kubestellar/klaude"
+    homepage: "https://github.com/kubestellar/kubestellar-mcp"
     description: "App-centric multi-cluster deployment and operations for Kubernetes"
     license: "Apache-2.0"
     install: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # kubestellar-mcp Makefile
 
-MODULE := github.com/kubestellar/klaude
+MODULE := github.com/kubestellar/kubestellar-mcp
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ brew install kubestellar-ops kubestellar-deploy
 
 ### From Releases
 
-Download from [GitHub Releases](https://github.com/kubestellar/klaude/releases).
+Download from [GitHub Releases](https://github.com/kubestellar/kubestellar-mcp/releases).
 
 ### From Source
 
 ```bash
-git clone https://github.com/kubestellar/klaude.git
-cd klaude
+git clone https://github.com/kubestellar/kubestellar-mcp.git
+cd kubestellar-mcp
 
 # Build both binaries
 go build -o bin/kubestellar-ops ./cmd/kubestellar-ops

--- a/cmd/kubestellar-deploy/main.go
+++ b/cmd/kubestellar-deploy/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	deploycmd "github.com/kubestellar/klaude/pkg/deploy/cmd"
+	deploycmd "github.com/kubestellar/kubestellar-mcp/pkg/deploy/cmd"
 )
 
 func main() {

--- a/cmd/kubestellar-ops/main.go
+++ b/cmd/kubestellar-ops/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/kubestellar/klaude/pkg/cmd"
+	"github.com/kubestellar/kubestellar-mcp/pkg/cmd"
 )
 
 func main() {

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,13 +79,13 @@ brew install kubestellar-ops kubestellar-deploy
 
 ### From Releases
 
-Download from [GitHub Releases](https://github.com/kubestellar/klaude/releases).
+Download from [GitHub Releases](https://github.com/kubestellar/kubestellar-mcp/releases).
 
 ### From Source
 
 ```bash
-git clone https://github.com/kubestellar/klaude.git
-cd klaude
+git clone https://github.com/kubestellar/kubestellar-mcp.git
+cd kubestellar-mcp
 
 # Build both binaries
 go build -o bin/kubestellar-ops ./cmd/kubestellar-ops
@@ -399,8 +399,8 @@ kubestellar-deploy --mcp-server
 
 ## Contributing
 
-Contributions are welcome! Please read our [contributing guidelines](https://github.com/kubestellar/klaude/blob/main/CONTRIBUTING.md).
+Contributions are welcome! Please read our [contributing guidelines](https://github.com/kubestellar/kubestellar-mcp/blob/main/CONTRIBUTING.md).
 
 ## License
 
-Apache License 2.0 - see [LICENSE](https://github.com/kubestellar/klaude/blob/main/LICENSE) for details.
+Apache License 2.0 - see [LICENSE](https://github.com/kubestellar/kubestellar-mcp/blob/main/LICENSE) for details.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubestellar/klaude
+module github.com/kubestellar/kubestellar-mcp
 
 go 1.22.0
 

--- a/pkg/cmd/ai/query.go
+++ b/pkg/cmd/ai/query.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/kubestellar/klaude/pkg/ai/claude"
-	"github.com/kubestellar/klaude/pkg/cluster"
+	"github.com/kubestellar/kubestellar-mcp/pkg/ai/claude"
+	"github.com/kubestellar/kubestellar-mcp/pkg/cluster"
 )
 
 type queryOptions struct {

--- a/pkg/cmd/clusters/health.go
+++ b/pkg/cmd/clusters/health.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/kubestellar/klaude/pkg/cluster"
+	"github.com/kubestellar/kubestellar-mcp/pkg/cluster"
 )
 
 type healthOptions struct {

--- a/pkg/cmd/clusters/list.go
+++ b/pkg/cmd/clusters/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/kubestellar/klaude/pkg/cluster"
+	"github.com/kubestellar/kubestellar-mcp/pkg/cluster"
 )
 
 type listOptions struct {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -11,11 +11,11 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/kubestellar/klaude/internal/version"
-	"github.com/kubestellar/klaude/pkg/cmd/ai"
-	"github.com/kubestellar/klaude/pkg/cmd/clusters"
-	"github.com/kubestellar/klaude/pkg/cmd/upgrade"
-	"github.com/kubestellar/klaude/pkg/mcp/server"
+	"github.com/kubestellar/kubestellar-mcp/internal/version"
+	"github.com/kubestellar/kubestellar-mcp/pkg/cmd/ai"
+	"github.com/kubestellar/kubestellar-mcp/pkg/cmd/clusters"
+	"github.com/kubestellar/kubestellar-mcp/pkg/cmd/upgrade"
+	"github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
 )
 
 var (

--- a/pkg/cmd/upgrade/watch.go
+++ b/pkg/cmd/upgrade/watch.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/kubestellar/klaude/pkg/progress"
+	"github.com/kubestellar/kubestellar-mcp/pkg/progress"
 )
 
 var (

--- a/pkg/deploy/cmd/root.go
+++ b/pkg/deploy/cmd/root.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kubestellar/klaude/pkg/deploy/mcp"
+	"github.com/kubestellar/kubestellar-mcp/pkg/deploy/mcp"
 )
 
 var (

--- a/pkg/deploy/mcp/server.go
+++ b/pkg/deploy/mcp/server.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kubestellar/klaude/pkg/multicluster"
+	"github.com/kubestellar/kubestellar-mcp/pkg/multicluster"
 )
 
 const (

--- a/pkg/deploy/mcp/tools_deploy.go
+++ b/pkg/deploy/mcp/tools_deploy.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/kubestellar/klaude/pkg/multicluster"
+	"github.com/kubestellar/kubestellar-mcp/pkg/multicluster"
 )
 
 // DeployResult represents the result of a deployment operation

--- a/pkg/deploy/mcp/tools_gitops.go
+++ b/pkg/deploy/mcp/tools_gitops.go
@@ -8,7 +8,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/kubestellar/klaude/pkg/gitops"
+	"github.com/kubestellar/kubestellar-mcp/pkg/gitops"
 )
 
 // GitOpsDriftResult aggregates drift results from multiple clusters

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/kubestellar/klaude/pkg/cluster"
+	"github.com/kubestellar/kubestellar-mcp/pkg/cluster"
 )
 
 const (

--- a/pkg/mcp/server/tools.go
+++ b/pkg/mcp/server/tools.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/kubestellar/klaude/pkg/gitops"
+	"github.com/kubestellar/kubestellar-mcp/pkg/gitops"
 )
 
 func (s *Server) toolListClusters(args map[string]interface{}) (string, bool) {


### PR DESCRIPTION
## Summary

- Updates the Go module path from `github.com/kubestellar/klaude` to `github.com/kubestellar/kubestellar-mcp` to match the renamed GitHub repository
- Updates all Go import paths across 13 source files
- Updates build configuration (`.goreleaser.yaml`, `Makefile`) with the new module path
- Updates documentation (`README.md`, `docs/index.md`) with the new repository URLs and clone paths

## Files Changed (18 files)

**Go module:**
- `go.mod` - Module declaration

**Go source files (13):**
- `cmd/kubestellar-ops/main.go`
- `cmd/kubestellar-deploy/main.go`
- `pkg/cmd/root.go`
- `pkg/cmd/ai/query.go`
- `pkg/cmd/clusters/health.go`
- `pkg/cmd/clusters/list.go`
- `pkg/cmd/upgrade/watch.go`
- `pkg/deploy/cmd/root.go`
- `pkg/deploy/mcp/server.go`
- `pkg/deploy/mcp/tools_deploy.go`
- `pkg/deploy/mcp/tools_gitops.go`
- `pkg/mcp/server/server.go`
- `pkg/mcp/server/tools.go`

**Build config:**
- `.goreleaser.yaml` - ldflags, homepage, release target
- `Makefile` - MODULE variable

**Documentation:**
- `README.md` - Clone URLs, GitHub links
- `docs/index.md` - Clone URLs, GitHub links

## Test plan

- [x] `go mod tidy` completes without errors
- [x] `go build ./cmd/kubestellar-ops` compiles successfully
- [x] `go build ./cmd/kubestellar-deploy` compiles successfully
- [x] No remaining references to `github.com/kubestellar/klaude` in the codebase (verified with grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)