### PR TITLE
🌱 Fix last klaude reference in goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -39,6 +39,6 @@ jobs:
             {
               "project": "kubestellar-mcp",
               "version": "${{ github.ref_name }}",
-              "source_repo": "kubestellar/klaude",
+              "source_repo": "kubestellar/kubestellar-mcp",
               "source_branch": "${{ github.ref_name }}"
             }


### PR DESCRIPTION
## Summary
- Update `source_repo` in `.github/workflows/goreleaser.yml` from `kubestellar/klaude` to `kubestellar/kubestellar-mcp`
- This was the last remaining reference to the old repo name

## Test plan
- [ ] Verify goreleaser workflow triggers correctly on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)