### PR TITLE
✨ Add nightly release workflow for MCP binaries

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,9 +1,14 @@
 name: goreleaser
 
+# Manual fallback — the primary release pipeline is release.yml (nightly cron).
+# Use this workflow only if you need to re-run GoReleaser on an existing tag.
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to release (e.g. v0.8.1)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,6 +21,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.tag }}
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -38,7 +44,7 @@ jobs:
           client-payload: |
             {
               "project": "kubestellar-mcp",
-              "version": "${{ github.ref_name }}",
+              "version": "${{ github.event.inputs.tag }}",
               "source_repo": "kubestellar/kubestellar-mcp",
-              "source_branch": "${{ github.ref_name }}"
+              "source_branch": "${{ github.event.inputs.tag }}"
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,272 @@
+name: Release
+
+on:
+  schedule:
+    # Nightly at 5 AM UTC (midnight Eastern during EST, 1 AM during EDT)
+    - cron: '0 5 * * *'
+    # Weekly on Sunday at 5 AM UTC
+    - cron: '0 5 * * 0'
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        default: 'nightly'
+        type: choice
+        options:
+          - nightly
+          - weekly
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: 'Dry run (no actual release)'
+        required: false
+        default: false
+        type: boolean
+      force_release:
+        description: 'Force release even without changes'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_name: ${{ steps.version.outputs.release_name }}
+      release_type: ${{ steps.type.outputs.release_type }}
+      is_prerelease: ${{ steps.type.outputs.is_prerelease }}
+      has_changes: ${{ steps.changes.outputs.has_changes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release type
+        id: type
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RELEASE_TYPE="${{ github.event.inputs.release_type }}"
+          elif [ "${{ github.event.schedule }}" = "0 5 * * 0" ]; then
+            RELEASE_TYPE="weekly"
+          else
+            RELEASE_TYPE="nightly"
+          fi
+
+          echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
+
+          # Only nightly builds are pre-releases; weekly builds are stable releases
+          if [ "$RELEASE_TYPE" = "nightly" ]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+          echo "Release type: $RELEASE_TYPE"
+
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          # Get latest version tag (including pre-releases for change detection)
+          LATEST_TAG=$(git tag -l 'v*' | sort -V | tail -n1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Latest tag: $LATEST_TAG"
+
+          # Get latest stable version tag (for version calculation)
+          LATEST_STABLE=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+          if [ -z "$LATEST_STABLE" ]; then
+            LATEST_STABLE="v0.0.0"
+          fi
+          echo "latest_stable=$LATEST_STABLE" >> $GITHUB_OUTPUT
+          echo "Latest stable tag: $LATEST_STABLE"
+
+      - name: Check for changes since last release
+        id: changes
+        run: |
+          LATEST_TAG="${{ steps.latest_tag.outputs.latest_tag }}"
+          FORCE="${{ github.event.inputs.force_release }}"
+          RELEASE_TYPE="${{ steps.type.outputs.release_type }}"
+
+          # For stable releases (weekly/patch/minor/major), always release
+          if [ "$RELEASE_TYPE" != "nightly" ]; then
+            echo "Stable release - proceeding"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check if forced
+          if [ "$FORCE" = "true" ]; then
+            echo "Force release requested"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check for any changes since last tag
+          if [ "$LATEST_TAG" = "v0.0.0" ]; then
+            echo "No previous tag - proceeding"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check for any changes at all
+          TOTAL_CHANGES=$(git rev-list "$LATEST_TAG"..HEAD --count)
+          if [ "$TOTAL_CHANGES" -gt 0 ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Total commits since last release: $TOTAL_CHANGES"
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes since last release"
+          fi
+
+      - name: Calculate new version
+        id: version
+        run: |
+          LATEST="${{ steps.latest_tag.outputs.latest_stable }}"
+          RELEASE_TYPE="${{ steps.type.outputs.release_type }}"
+          DATE=$(date +%Y%m%d)
+
+          # Remove 'v' prefix
+          VERSION=${LATEST#v}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          PATCH=$(echo $VERSION | cut -d. -f3)
+
+          case $RELEASE_TYPE in
+            nightly)
+              NEW_VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))-nightly.${DATE}"
+              RELEASE_NAME="$NEW_VERSION"
+              ;;
+            weekly)
+              NEW_VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+              RELEASE_NAME="${NEW_VERSION}-weekly"
+              ;;
+            patch)
+              NEW_VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+              RELEASE_NAME="$NEW_VERSION"
+              ;;
+            minor)
+              NEW_VERSION="v${MAJOR}.$((MINOR + 1)).0"
+              RELEASE_NAME="$NEW_VERSION"
+              ;;
+            major)
+              NEW_VERSION="v$((MAJOR + 1)).0.0"
+              RELEASE_NAME="$NEW_VERSION"
+              ;;
+          esac
+
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION (release name: $RELEASE_NAME)"
+
+  test:
+    runs-on: ubuntu-latest
+    needs: determine-version
+    if: needs.determine-version.outputs.has_changes == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Build binaries
+        run: go build ./...
+
+  release:
+    needs: [determine-version, test]
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.dry_run != 'true' && needs.determine-version.outputs.has_changes == 'true' }}
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Check if tag exists
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists, force updating..."
+            git tag -d "$VERSION"
+            git push origin ":refs/tags/$VERSION" || true
+          fi
+
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          RELEASE_NAME: ${{ needs.determine-version.outputs.release_name }}
+
+      - name: Trigger docs version branch
+        if: needs.determine-version.outputs.is_prerelease == 'false'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
+          repository: kubestellar/docs
+          event-type: create-version-branch
+          client-payload: |
+            {
+              "project": "kubestellar-mcp",
+              "version": "${{ needs.determine-version.outputs.version }}",
+              "source_repo": "kubestellar/kubestellar-mcp",
+              "source_branch": "${{ needs.determine-version.outputs.version }}"
+            }
+
+  notify:
+    needs: [determine-version, release]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Release summary
+        run: |
+          echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ needs.determine-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Type**: ${{ needs.determine-version.outputs.release_type }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Pre-release**: ${{ needs.determine-version.outputs.is_prerelease }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Has changes**: ${{ needs.determine-version.outputs.has_changes }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ needs.determine-version.outputs.has_changes }}" != "true" ]; then
+            echo "### Skipped" >> $GITHUB_STEP_SUMMARY
+            echo "No changes since last release. Release was skipped." >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.release.result }}" = "success" ]; then
+            echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
+            echo "- GitHub Release: https://github.com/${{ github.repository }}/releases/tag/${{ needs.determine-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+            echo "- Homebrew: \`brew upgrade kubestellar-ops kubestellar-deploy\` (formulas updated)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Status: ${{ needs.release.result }}" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary
- Adds `release.yml` with nightly/weekly cron (5 AM UTC, matching console and claude-plugins schedules)
- GoReleaser builds `kubestellar-ops` + `kubestellar-deploy` binaries and updates homebrew-tap formulas automatically
- Changes `goreleaser.yml` from tag-push trigger to `workflow_dispatch` only (manual fallback), preventing double-releases

## Details

### `release.yml` (new)
- **Cron**: `0 5 * * *` nightly, `0 5 * * 0` weekly (same as console/claude-plugins)
- **Manual dispatch**: `nightly`, `weekly`, `patch`, `minor`, `major` release types + dry-run + force options
- **Change detection**: Skips nightly if no commits since last tag
- **Version format**: `v{major}.{minor}.{patch+1}-nightly.{YYYYMMDD}` for nightly, semantic for stable
- **GoReleaser**: Builds both binaries, pushes to GitHub releases, updates homebrew-tap
- **Docs**: Triggers `create-version-branch` on kubestellar/docs for stable releases

### `goreleaser.yml` (modified)
- Removed `push: tags: "v*"` trigger (would double-fire when release.yml pushes a tag)
- Now `workflow_dispatch` only with tag input, as a manual re-release fallback

## Test plan
- [ ] Push branch, verify CI passes
- [ ] After merge, manually trigger: `gh workflow run release.yml -f release_type=nightly`
- [ ] Verify GitHub release created with kubestellar-ops and kubestellar-deploy binaries
- [ ] Verify homebrew-tap formulas updated
- [ ] Verify `brew update && brew upgrade kubestellar-ops kubestellar-deploy` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)