### PR TITLE
📖 Add /plugin install CLI commands to Step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ In Claude Code, run:
 
 ### Step 2: Install the Plugins
 
-Go to `/plugin` → **Discover** tab → Install **kubestellar-ops** and/or **kubestellar-deploy**.
+```
+/plugin install kubestellar-ops
+/plugin install kubestellar-deploy
+```
+
+Or go to `/plugin` → **Discover** tab → Install **kubestellar-ops** and/or **kubestellar-deploy**.
 
 ### Step 3: Verify
 


### PR DESCRIPTION
## Summary
- Add `/plugin install kubestellar-ops` and `/plugin install kubestellar-deploy` as the primary install method
- Keep Discover tab as alternative

## Test plan
- [ ] Verify `/plugin install` commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)