### PR TITLE
🐛 Fix nil pointer crash in get_pods when StartTime is nil

### DIFF
--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"sync"
 
@@ -1033,6 +1034,10 @@ func (s *Server) send(resp Response) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, _ := json.Marshal(resp)
+	data, err := json.Marshal(resp)
+	if err != nil {
+		log.Printf("Failed to marshal MCP response: %v", err)
+		return
+	}
 	fmt.Fprintf(s.writer, "%s\n", data)
 }

--- a/pkg/mcp/server/tools.go
+++ b/pkg/mcp/server/tools.go
@@ -180,11 +180,16 @@ func (s *Server) toolGetPods(ctx context.Context, args map[string]interface{}) (
 			}
 		}
 
+		startTime := "<pending>"
+		if pod.Status.StartTime != nil {
+			startTime = pod.Status.StartTime.Format("2006-01-02 15:04:05")
+		}
+
 		sb.WriteString(fmt.Sprintf("%-50s %-12s %d/%d   %s\n",
 			pod.Namespace+"/"+pod.Name,
 			status,
 			ready, total,
-			pod.Status.StartTime.Format("2006-01-02 15:04:05")))
+			startTime))
 	}
 
 	return sb.String(), false


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference on `pod.Status.StartTime` in `toolGetPods` that crashes the MCP server when querying pods that haven't started yet
- Add error handling in `send()` to log `json.Marshal` failures instead of silently discarding them

## Root Cause
`pod.Status.StartTime` is a `*metav1.Time` pointer — nil for pending pods. Calling `.Format()` on nil panics and kills the MCP server, dropping the connection for all subsequent tool calls.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI build/lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)