### PR TITLE
🐛 Remove MikeSpreworthy from OWNERS (invalid username)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,10 +2,8 @@ approvers:
   - clubanderson
   - dumb0002
   - pdettori
-  - MikeSpreworthy
 
 reviewers:
   - clubanderson
   - dumb0002
   - pdettori
-  - MikeSpreworthy


### PR DESCRIPTION
## Summary
- Remove `MikeSpreworthy` from OWNERS — this is a typo/invalid GitHub username

## Test plan
- [ ] Verify OWNERS file updated