### PR TITLE
fix: handle notifications/initialized in MCP handshake

### DIFF
--- a/pkg/deploy/mcp/server.go
+++ b/pkg/deploy/mcp/server.go
@@ -109,6 +109,9 @@ func (s *Server) handleRequest(req *MCPRequest) *MCPResponse {
 		return s.handleListTools(req)
 	case "tools/call":
 		return s.handleToolCall(ctx, req)
+	case "initialized", "notifications/initialized":
+		// No response needed for MCP lifecycle notification
+		return nil
 	default:
 		return &MCPResponse{
 			JSONRPC: "2.0",

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -152,7 +152,7 @@ func (s *Server) handleRequest(ctx context.Context, req *Request) {
 	switch req.Method {
 	case "initialize":
 		s.handleInitialize(req)
-	case "initialized":
+	case "initialized", "notifications/initialized":
 		// No response needed for notification
 	case "tools/list":
 		s.handleToolsList(req)


### PR DESCRIPTION
## Summary
- Both MCP servers (`kubestellar-ops` and `kubestellar-deploy`) return `-32601 Method not found` when Claude Code sends `notifications/initialized` during the MCP handshake, causing Claude Code to mark both servers as "failed"
- The ops server handled the short form `initialized` but not the full MCP method name `notifications/initialized`
- The deploy server handled neither form and always returned an error response (even for notifications that should be silent)
- Added `notifications/initialized` to both servers' method routing so the notification is silently accepted

Fixes #25

## Test plan
- [ ] Build both binaries: `go build ./cmd/kubestellar-ops` and `go build ./cmd/kubestellar-deploy`
- [ ] Send full MCP handshake sequence (initialize + notifications/initialized + tools/list) via stdin and verify no error response for the notification
- [ ] Install updated plugins in Claude Code and verify both show "connected" instead of "failed"

## Changes
- `pkg/mcp/server/server.go`: Added `"notifications/initialized"` to the existing `"initialized"` case
- `pkg/deploy/mcp/server.go`: Added new case for `"initialized"` and `"notifications/initialized"` returning `nil` (no response)