### PR TITLE
Add Dockerfile for MCP server (Glama registration)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+bin/
+.git/
+.github/
+docs/
+*.md
+!go.mod
+!go.sum
+LICENSE
+DCO
+.goreleaser.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /kubestellar-ops ./cmd/kubestellar-ops
+
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /kubestellar-ops /usr/local/bin/kubestellar-ops
+
+ENTRYPOINT ["kubestellar-ops", "--mcp-server"]


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile that builds `kubestellar-ops` and runs it in MCP server mode (`--mcp-server`, stdio transport)
- Add `.dockerignore` to keep build context lean

## Why

The [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) repo requires every listed MCP server to be registered on [Glama](https://glama.ai/mcp/servers) with a score badge. Glama needs a Dockerfile to run automated checks (start the server and verify it responds to MCP introspection requests).

This unblocks [punkpeye/awesome-mcp-servers#5343](https://github.com/punkpeye/awesome-mcp-servers/pull/5343).

## Test plan

- [ ] `docker build -t kubestellar-ops-mcp .` completes successfully
- [ ] `echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | docker run -i kubestellar-ops-mcp` returns a valid MCP initialize response
- [ ] Register on Glama and verify score badge renders