### PR TITLE
fix(gitops): detect unchanged resources in dry-run sync

### DIFF
--- a/pkg/gitops/sync.go
+++ b/pkg/gitops/sync.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,40 +203,45 @@ func (s *Syncer) syncResource(ctx context.Context, manifest Manifest, mapping re
 		return result, nil
 	}
 
-	// Resource exists - update it using server-side apply
-	if dryRun {
-		result.Action = SyncActionUpdated
-		result.Message = "Would update (dry-run)"
-		return result, nil
-	}
-
 	// Use server-side apply for updates
 	data, err := json.Marshal(obj.Object)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal: %w", err)
 	}
 
+	patchOpts := metav1.PatchOptions{
+		FieldManager: "kubestellar-deploy",
+		Force:        boolPtr(true),
+	}
+	if dryRun {
+		patchOpts.DryRun = []string{metav1.DryRunAll}
+	}
+
 	var updated *unstructured.Unstructured
 	if mapping.ClusterScoped {
 		updated, err = s.dynClient.Resource(mapping.GVR).Patch(ctx, manifest.Metadata.Name,
-			types.ApplyPatchType, data, metav1.PatchOptions{
-				FieldManager: "kubestellar-deploy",
-				Force:        boolPtr(true),
-			})
+			types.ApplyPatchType, data, patchOpts)
 	} else {
 		updated, err = s.dynClient.Resource(mapping.GVR).Namespace(namespace).Patch(ctx, manifest.Metadata.Name,
-			types.ApplyPatchType, data, metav1.PatchOptions{
-				FieldManager: "kubestellar-deploy",
-				Force:        boolPtr(true),
-			})
+			types.ApplyPatchType, data, patchOpts)
 	}
 
 	if err != nil {
+		if dryRun {
+			return nil, fmt.Errorf("failed to dry-run update: %w", err)
+		}
 		return nil, fmt.Errorf("failed to update: %w", err)
 	}
 
-	// Check if anything actually changed
-	if existing.GetResourceVersion() == updated.GetResourceVersion() {
+	// Dry-run apply is not persisted, so resourceVersion cannot reliably signal
+	// whether the apply would change the live object.
+	if dryRun && syncObjectsEqual(existing.Object, updated.Object) {
+		result.Action = SyncActionUnchanged
+		result.Message = "No changes (dry-run)"
+	} else if dryRun {
+		result.Action = SyncActionUpdated
+		result.Message = "Would update (dry-run)"
+	} else if existing.GetResourceVersion() == updated.GetResourceVersion() {
 		result.Action = SyncActionUnchanged
 		result.Message = "No changes"
 	} else {
@@ -244,6 +250,57 @@ func (s *Syncer) syncResource(ctx context.Context, manifest Manifest, mapping re
 	}
 
 	return result, nil
+}
+
+func syncObjectsEqual(a, b map[string]interface{}) bool {
+	return apiequality.Semantic.DeepEqual(normalizeSyncObject(a, nil), normalizeSyncObject(b, nil))
+}
+
+func normalizeSyncObject(value interface{}, path []string) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		normalized := make(map[string]interface{}, len(typed))
+		for key, val := range typed {
+			if shouldIgnoreSyncField(path, key) {
+				continue
+			}
+			nextPath := make([]string, len(path)+1)
+			copy(nextPath, path)
+			nextPath[len(path)] = key
+			normalized[key] = normalizeSyncObject(val, nextPath)
+		}
+		return normalized
+	case []interface{}:
+		normalized := make([]interface{}, len(typed))
+		for i, val := range typed {
+			normalized[i] = normalizeSyncObject(val, path)
+		}
+		return normalized
+	default:
+		return typed
+	}
+}
+
+func shouldIgnoreSyncField(path []string, key string) bool {
+	if len(path) == 0 && key == "status" {
+		return true
+	}
+
+	if len(path) == 1 && path[0] == "metadata" {
+		switch key {
+		case "resourceVersion", "uid", "creationTimestamp", "generation", "managedFields", "selfLink":
+			return true
+		}
+	}
+
+	if len(path) == 1 && path[0] == "spec" {
+		switch key {
+		case "clusterIP", "clusterIPs":
+			return true
+		}
+	}
+
+	return false
 }
 
 // shouldSync checks if a kind should be synced

--- a/pkg/gitops/sync_test.go
+++ b/pkg/gitops/sync_test.go
@@ -47,26 +47,26 @@ func TestSyncCreatesResourcesAndTracksSkippedKinds(t *testing.T) {
 
 func TestSyncUpdatesAndDetectsUnchangedResources(t *testing.T) {
 	tests := []struct {
-		name               string
-		updatedRV          string
-		wantAction         SyncAction
-		wantUpdated        int
-		wantUnchanged      int
-		wantMessageSnippet string
+		name          string
+		updatedRV     string
+		wantAction    SyncAction
+		wantUpdated   int
+		wantUnchanged int
+		wantMessage   string
 	}{
 		{
-			name:               "updated resource",
-			updatedRV:          "2",
-			wantAction:         SyncActionUpdated,
-			wantUpdated:        1,
-			wantMessageSnippet: "Updated (rv: 1 -> 2)",
+			name:        "updated resource",
+			updatedRV:   "2",
+			wantAction:  SyncActionUpdated,
+			wantUpdated: 1,
+			wantMessage: "Updated (rv: 1 -> 2)",
 		},
 		{
-			name:               "unchanged resource",
-			updatedRV:          "1",
-			wantAction:         SyncActionUnchanged,
-			wantUnchanged:      1,
-			wantMessageSnippet: "No changes",
+			name:          "unchanged resource",
+			updatedRV:     "1",
+			wantAction:    SyncActionUnchanged,
+			wantUnchanged: 1,
+			wantMessage:   "No changes",
 		},
 	}
 
@@ -105,10 +105,161 @@ func TestSyncUpdatesAndDetectsUnchangedResources(t *testing.T) {
 			if summary.Results[0].Action != tt.wantAction {
 				t.Fatalf("action = %q, want %q", summary.Results[0].Action, tt.wantAction)
 			}
-			if summary.Results[0].Message != tt.wantMessageSnippet {
-				t.Fatalf("message = %q, want %q", summary.Results[0].Message, tt.wantMessageSnippet)
+			if summary.Results[0].Message != tt.wantMessage {
+				t.Fatalf("message = %q, want %q", summary.Results[0].Message, tt.wantMessage)
 			}
 		})
+	}
+}
+
+func TestSyncDryRunPatchesExistingResourcesAndDetectsUnchanged(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingValue string
+		wantAction    SyncAction
+		wantUpdated   int
+		wantUnchanged int
+		wantMessage   string
+	}{
+		{
+			name:          "would update",
+			existingValue: "old",
+			wantAction:    SyncActionUpdated,
+			wantUpdated:   1,
+			wantMessage:   "Would update (dry-run)",
+		},
+		{
+			name:          "unchanged",
+			existingValue: "value",
+			wantAction:    SyncActionUnchanged,
+			wantUnchanged: 1,
+			wantMessage:   "No changes (dry-run)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := testManifestObject("ConfigMap", "demo", "apps", "1")
+			existing.Object["data"].(map[string]interface{})["key"] = tt.existingValue
+			client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), existing)
+			patchCalled := false
+			client.PrependReactor("patch", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				patchCalled = true
+				patchAction, ok := action.(k8stesting.PatchAction)
+				if !ok {
+					t.Fatalf("patch action type = %T, want PatchAction", action)
+				}
+				if patchAction.GetPatchType() != types.ApplyPatchType {
+					t.Fatalf("patch type = %v, want %v", patchAction.GetPatchType(), types.ApplyPatchType)
+				}
+				patchOptionsGetter, ok := action.(interface {
+					GetPatchOptions() metav1.PatchOptions
+				})
+				if !ok {
+					t.Fatalf("patch action type = %T, want GetPatchOptions", action)
+				}
+				patchOpts := patchOptionsGetter.GetPatchOptions()
+				if patchOpts.FieldManager != "kubestellar-deploy" {
+					t.Fatalf("field manager = %q, want kubestellar-deploy", patchOpts.FieldManager)
+				}
+				if patchOpts.Force == nil || !*patchOpts.Force {
+					t.Fatalf("force option = %v, want true", patchOpts.Force)
+				}
+				if len(patchOpts.DryRun) != 1 || patchOpts.DryRun[0] != metav1.DryRunAll {
+					t.Fatalf("dry-run options = %v, want [%s]", patchOpts.DryRun, metav1.DryRunAll)
+				}
+
+				var raw map[string]interface{}
+				if err := json.Unmarshal(patchAction.GetPatch(), &raw); err != nil {
+					t.Fatalf("json.Unmarshal() error = %v", err)
+				}
+				updated := &unstructured.Unstructured{Object: raw}
+				updated.SetResourceVersion("1")
+				return true, updated, nil
+			})
+
+			summary, err := (&Syncer{dynClient: client}).Sync(context.Background(), []Manifest{testManifest("v1", "ConfigMap", "demo", "apps")}, "alpha", SyncOptions{DryRun: true})
+			if err != nil {
+				t.Fatalf("Sync() error = %v", err)
+			}
+			if !patchCalled {
+				t.Fatal("expected dry-run sync to patch existing resource")
+			}
+			if summary.Updated != tt.wantUpdated || summary.Unchanged != tt.wantUnchanged {
+				t.Fatalf("unexpected summary counts: %#v", summary)
+			}
+			if len(summary.Results) != 1 {
+				t.Fatalf("result count = %d, want 1", len(summary.Results))
+			}
+			if summary.Results[0].Action != tt.wantAction {
+				t.Fatalf("action = %q, want %q", summary.Results[0].Action, tt.wantAction)
+			}
+			if summary.Results[0].Message != tt.wantMessage {
+				t.Fatalf("message = %q, want %q", summary.Results[0].Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestSyncObjectsEqualIgnoresOnlyKubernetesManagedPaths(t *testing.T) {
+	current := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":            "demo",
+			"resourceVersion": "1",
+			"managedFields":   []interface{}{map[string]interface{}{"manager": "other"}},
+		},
+		"data": map[string]interface{}{
+			"status":     "ready",
+			"generation": "1",
+		},
+		"status": map[string]interface{}{
+			"observedGeneration": float64(1),
+		},
+	}
+	dryRun := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":            "demo",
+			"resourceVersion": "2",
+			"managedFields":   []interface{}{map[string]interface{}{"manager": "kubestellar-deploy"}},
+		},
+		"data": map[string]interface{}{
+			"status":     "ready",
+			"generation": "1",
+		},
+		"status": map[string]interface{}{
+			"observedGeneration": float64(2),
+		},
+	}
+
+	if !syncObjectsEqual(current, dryRun) {
+		t.Fatal("syncObjectsEqual() should ignore Kubernetes-managed metadata and top-level status changes")
+	}
+
+	dryRun["data"].(map[string]interface{})["generation"] = "2"
+	if syncObjectsEqual(current, dryRun) {
+		t.Fatal("syncObjectsEqual() should not ignore user data keys named like Kubernetes-managed fields")
+	}
+
+	currentPod := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"spec": map[string]interface{}{
+			"nodeName": "node-a",
+		},
+	}
+	dryRunPod := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"spec": map[string]interface{}{
+			"nodeName": "node-b",
+		},
+	}
+	if syncObjectsEqual(currentPod, dryRunPod) {
+		t.Fatal("syncObjectsEqual() should not ignore spec.nodeName changes")
 	}
 }
 


### PR DESCRIPTION
Fixes #160.

## Summary
- run the existing-resource server-side apply path during dry-run with `DryRun: ["All"]` instead of always returning `Would update`
- compare the dry-run apply result against the live object, ignoring Kubernetes-managed metadata/status fields, so unchanged resources report `No changes (dry-run)`
- keep the real apply path's resourceVersion comparison unchanged
- add regression coverage for dry-run patch options, changed vs unchanged dry-run results, and user data keys named like managed fields

## Tests
- `docker run --rm -v 'D:/home/income_scout/bounty_submissions/kubestellar-mcp:/src' -w /src golang:1.26 go test ./pkg/gitops`
- `docker run --rm -v 'D:/home/income_scout/bounty_submissions/kubestellar-mcp:/src' -w /src golang:1.26 go test ./...`