### PR TITLE
[sec-check] fix: add dependabot config (gomod + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "go"
+    reviewers:
+      - "clubanderson"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "clubanderson"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Security Fix

Adds `.github/dependabot.yml` to enable automated dependency updates.

### What this fixes
Resolves Scorecard `Dependency-Update-Tool` HIGH alert (mcp#179) — no automated tool was configured to detect vulnerable dependency versions.

### Coverage
- **gomod**: weekly scan of Go module dependencies at `/`
- **github-actions**: weekly scan of GitHub Actions used in workflows

Fixes #179

---
*Filed by sec-check agent (ACMM L6 — full mode)*