### PR TITLE
🌱 Sync workflows from kubestellar/infra

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,4 +9,5 @@ permissions:
 
 jobs:
   label:
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
+    secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -19,10 +19,7 @@ permissions:
 
 jobs:
   ai-fix:
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   assignment-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -22,10 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   copilot-dco:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,4 +10,5 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
+    secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,13 +6,12 @@ on:
   issues:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   greet:
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,4 +11,5 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,10 +4,11 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  checks: write
+  pull-requests: read
+
 jobs:
   verify:
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      checks: write
-      pull-requests: read
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,4 +15,5 @@ permissions:
 
 jobs:
   analysis:
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,4 +10,5 @@ permissions:
 
 jobs:
   stale:
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
+    secrets: inherit


### PR DESCRIPTION
This PR syncs the caller workflows from `kubestellar/infra`.

These workflows call reusable workflows from `kubestellar/infra`:

**Standard Workflows:**
- `add-help-wanted.yml` - Add help-wanted label to issues
- `assignment-helper.yml` - Handle issue assignments
- `feedback.yml` - Collect feedback
- `greetings.yml` - Welcome new contributors
- `label-helper.yml` - Manage labels
- `pr-verifier.yml` - Verify PR contents
- `pr-verify-title.yml` - Verify PR title format
- `scorecard.yml` - Security scorecard
- `stale.yml` - Mark stale issues/PRs

**Agentic Workflows (Copilot Integration):**
- `ai-fix.yml` - Assign Copilot to issues with `ai-fix-requested` label
- `copilot-automation.yml` - Automate Copilot PR processing (DCO, labels)
- `copilot-dco.yml` - Override DCO for Copilot PRs

Auto-generated by workflow sync