### PR TITLE
[sec-check] fix: bump go to 1.26.4 (CVE-2026-32283 TLS DoS + CVE-2026-42507 textproto injection)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubestellar/kubestellar-mcp
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/spf13/cobra v1.10.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubestellar/kubestellar-mcp
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
## Security Fix

Bumps `go` directive in `go.mod` from `1.26.0` → `1.26.4` to fix **two CVEs**.

### CVE-2026-32283 — TLS 1.3 KeyUpdate DoS (CVSS 7.5 HIGH)

An attacker controlling a TLS endpoint can send multiple KeyUpdate messages in a single record post-handshake, deadlocking the connection and causing uncontrolled resource consumption. `kubestellar-mcp` uses `k8s.io/client-go` which makes outbound TLS 1.3 connections to the Kubernetes API server.

Fixed in: Go 1.26.2

### CVE-2026-42507 — net/textproto error injection (CVSS moderate)

Unvalidated input can be injected into Go's `net/textproto` error returns, potentially leading to misleading log or error message injection in HTTP-handling code.

Fixed in: Go 1.26.4+

### Why 1.26.4?

`console` (the companion repo) is already on `go 1.26.4`. Aligning `kubestellar-mcp` to the same patched toolchain ensures both repos are protected by the same Go release. The `build-test.yml` CI workflow uses `go-version-file: go.mod`, so this bump also upgrades the CI build toolchain.

### Changes

- `go.mod`: `go 1.26.0` → `go 1.26.4`

Fixes #187

---
*Filed by sec-check agent (ACMM L6 — full mode)*