### PR TITLE
📖 [strategist] planning: add KubeStellar platform context to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ AI-powered multi-cluster Kubernetes tools for Claude Code.
 
 **Single-cluster UX for multi-cluster reality** - work with your **apps**, not your **clusters**.
 
+## Why KubeStellar
+
+`kubestellar-mcp` is the AI entry point to the **KubeStellar platform** — a CNCF Sandbox ecosystem for multi-cluster Kubernetes orchestration.
+
+| Sub-project | Role |
+|-------------|------|
+| [kubestellar](https://github.com/kubestellar/kubestellar) | Core engine — BindingPolicy, WDS, ITS, WEC workload propagation |
+| [console](https://github.com/kubestellar/console) | Web dashboard — 160+ cards, AI missions, GPU and LLM-d monitoring |
+| [console-marketplace](https://github.com/kubestellar/console-marketplace) | 153+ community card presets (GPU/AI/ML, ArgoCD, OPA, Falco, security) |
+| [console-kb](https://github.com/kubestellar/console-kb) | AI knowledge base — community missions and operational runbooks |
+| **kubestellar-mcp** | **This repo** — MCP server for Claude, Cursor, Windsurf, VS Code |
+
+`kubestellar-mcp` lets AI agents inspect and operate clusters through natural language. For visual dashboards and AI missions, see [KubeStellar Console](https://console.kubestellar.io).
+
 ## Components
 
 | Binary | Description |
@@ -415,6 +429,7 @@ kubestellar-deploy completion bash
 ## Related Projects
 
 - [KubeStellar](https://kubestellar.io) - Multi-cluster orchestration platform
+- [KubeStellar Console](https://console.kubestellar.io) - AI-powered web dashboard for multi-cluster management
 
 ## Contributing
 


### PR DESCRIPTION
## Planning Artifact

Adds a `## Why KubeStellar` section to the README that explains `kubestellar-mcp` as the AI entry point to the KubeStellar platform.

### What this adds

- **Platform context table** — shows all 5 KubeStellar sub-projects (kubestellar, console, console-marketplace, console-kb, kubestellar-mcp) with their roles
- **Differentiation** — clearly separates kubestellar-mcp (AI agent natural-language interface) from Console (visual dashboard)
- **Discoverability** — first-time evaluators landing on the MCP repo now understand the multi-cluster context and can navigate to the broader platform
- **Related Projects** section — updated to include KubeStellar Console link

### Why now

Issue #3802 identifies that kubestellar-mcp has no cross-project narrative. The ROADMAP.md (merged PR#182) calls out "Link from main kubestellar/kubestellar README ecosystem section" as a near-term item. This PR delivers the reverse: the MCP repo now explains its place in the platform.

Addresses: kubestellar/kubestellar#3802 (AI-native positioning gap)
Related: kubestellar/kubestellar#3812, PR#3817 (ECOSYSTEM.md)

---
*Filed by strategist agent (ACMM L6 — full mode)*