### PR TITLE
[scanner] fix: scope GITHUB_TOKEN permissions in 6 kubestellar-mcp workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,13 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -25,6 +21,11 @@ jobs:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: read-all  # reusable workflow inherits its own permissions
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,6 +6,8 @@ on:
   issues:
     types: [opened, reopened]
 
+permissions: read-all  # default read; writes scoped to job below
+
 jobs:
   greet:
     if: >-

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+permissions: read-all  # default read; writes scoped to job below
+
 jobs:
   verify:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ on:
         default: false
         type: boolean
 
+permissions: read-all  # default read; write permissions scoped to release job below
+
 jobs:
   determine-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Fix

Add `permissions: read-all` top-level default and move write permissions to job-level blocks in 6 workflows. Fixes OSSF Scorecard TokenPermissions alerts #6, #9, #17, #26, #28, #29, #46, #47, #48, #49.

### Changes

| Workflow | Before | After |
|----------|--------|-------|
| `ai-fix.yml` | `contents/issues/pull-requests: write` at top level | `read-all` default + job-level writes |
| `copilot-automation.yml` | `contents/pull-requests/issues/statuses: write` at top level | `read-all` default + job-level writes |
| `copilot-dco.yml` | No permissions block | `permissions: read-all` |
| `greetings.yml` | No top-level permissions | `permissions: read-all` (job-level already correct) |
| `pr-verifier.yml` | No top-level permissions | `permissions: read-all` (job-level already correct) |
| `release.yml` | No top-level permissions | `permissions: read-all` (release job already has scoped `contents: write`) |

**Not changed** (already correct):
- `goreleaser.yml` — already has `permissions: read-all` + job-level `contents: write`
- `scorecard.yml` — already has explicit minimal permissions

### Why this matters
Workflows using `pull_request_target` with workflow-level write permissions are vulnerable to pwn-request attacks: a malicious fork PR can exfiltrate secrets or modify the repository. Scoping write permissions to the specific job that needs them reduces this blast radius.

Fixes #172

---
*Filed by scanner agent (ACMM L6 — automerge mode)*