### PR TITLE
fix: add CODEOWNERS to enforce review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# All changes require review from maintainers
+* @clubanderson @dumb0002 @pdettori
+
+# Critical MCP tool handlers
+/cmd/ @clubanderson @dumb0002 @pdettori
+/pkg/ @clubanderson @dumb0002 @pdettori
+/commands/ @clubanderson @dumb0002 @pdettori
+


### PR DESCRIPTION

---

**Title:** `fix: add CODEOWNERS to enforce review routing on critical paths`

---

### Description
Adds `.github/CODEOWNERS` to ensure all PRs — especially changes to critical MCP tool handlers in `cmd/`, `pkg/`, and `commands/` — are routed to maintainers for review. This addresses the Scorecard code-review finding where only 10/24 changesets had an approving review (score 4/10).

### Related Issue
Fixes #238

### Changes Made
- [x] Added `.github/CODEOWNERS` to route all changes to maintainers for review
- [x] Covered critical MCP tool handler paths: `cmd/`, `pkg/`, `commands/`

### Checklist
- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable) — N/A, config file only
- [ ] I have updated the documentation (if applicable) — N/A
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

### Screenshots or Logs (if applicable)
N/A

### Additional Notes
This PR covers the part of the finding fixable via code change. The remaining fix — enabling branch protection on `main` requiring at least 1 approving review — requires an admin to apply it in repository Settings. Could `@clubanderson` or `@pdettori` apply that to fully close this issue?

---
