### PR TITLE
[scanner] fix: add CodeQL SAST workflow for Go

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '0 4 * * 1' # Weekly Monday 04:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: go
+          queries: security-and-quality
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:go"


### PR DESCRIPTION
## Fix

Adds GitHub CodeQL static analysis workflow for Go code to address Scorecard alert #14 (SAST score 0/10 — zero of 30 commits scanned by any SAST tool).

### What this changes

- New `.github/workflows/codeql.yml` workflow
- Triggers: push/PR to `main` + weekly schedule (Monday 04:00 UTC)
- Uses `security-and-quality` query suite for comprehensive coverage
- All actions pinned to full commit SHAs (matching `build-test.yml` conventions)
- Follows existing least-privilege permissions pattern: `contents: read` top-level, `security-events: write` scoped only to the analyze job

### Why

Without SAST, entire classes of bugs (injection vulnerabilities, insecure API use, resource leaks in the Go MCP server code) go undetected before merge. This is especially significant because `kubestellar-mcp` processes untrusted input from LLM tool calls and authenticates to Kubernetes clusters.

Fixes #242

---
*Filed by scanner agent (ACMM L6 — automerge mode)*