### PR TITLE
[quality] add unit tests for tool_registry.go infrastructure

### DIFF
--- a/pkg/mcp/server/tool_registry_test.go
+++ b/pkg/mcp/server/tool_registry_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindToolHandler_ReturnsNilForUnknownTool(t *testing.T) {
+	handler := findToolHandler("completely_nonexistent_tool_xyz")
+	assert.Nil(t, handler, "findToolHandler should return nil for unknown tool names")
+}
+
+func TestRegisteredTools_ReturnsNonEmptyList(t *testing.T) {
+	tools := registeredTools()
+	require.NotEmpty(t, tools, "registeredTools() should return tools after init()")
+}
+
+func TestRegisteredTools_AllHaveNonEmptyName(t *testing.T) {
+	tools := registeredTools()
+	for i, tool := range tools {
+		assert.NotEmpty(t, tool.Name, "tool at index %d has empty Name", i)
+	}
+}
+
+func TestRegisteredTools_AllHaveDescription(t *testing.T) {
+	tools := registeredTools()
+	for _, tool := range tools {
+		assert.NotEmpty(t, tool.Description, "tool %q has empty Description", tool.Name)
+	}
+}
+
+func TestRegisteredTools_AllHaveHandler(t *testing.T) {
+	for _, td := range toolRegistry {
+		assert.NotNil(t, td.Handler, "tool %q has nil handler", td.Schema.Name)
+	}
+}
+
+func TestRegisteredTools_NoDuplicateNames(t *testing.T) {
+	seen := make(map[string]int)
+	for _, td := range toolRegistry {
+		seen[td.Schema.Name]++
+	}
+	for name, count := range seen {
+		assert.Equal(t, 1, count, "tool %q is registered %d times (expected 1)", name, count)
+	}
+}
+
+func TestFindToolHandler_ReturnsHandlerForKnownTool(t *testing.T) {
+	// list_clusters is registered by tools_cluster_registry.go init()
+	handler := findToolHandler("list_clusters")
+	require.NotNil(t, handler, "findToolHandler should find 'list_clusters'")
+}
+
+func TestRegisteredTools_CountMatchesRegistry(t *testing.T) {
+	tools := registeredTools()
+	assert.Equal(t, len(toolRegistry), len(tools),
+		"registeredTools() length should match toolRegistry length")
+}
+
+func TestRegisteredTools_InputSchemaHasObjectType(t *testing.T) {
+	for _, td := range toolRegistry {
+		assert.Equal(t, "object", td.Schema.InputSchema.Type,
+			"tool %q InputSchema.Type should be 'object'", td.Schema.Name)
+	}
+}


### PR DESCRIPTION
## Test Improvement

Adds dedicated unit tests for the tool registry infrastructure (`tool_registry.go`) introduced in PR #256. The registry is the single dispatch point for all 38+ MCP tools, yet had zero dedicated test coverage.

### Tests added

| Test | Purpose |
|------|---------|
| `TestFindToolHandler_ReturnsNilForUnknownTool` | Verifies nil return for missing tools |
| `TestFindToolHandler_ReturnsHandlerForKnownTool` | Verifies lookup of `list_clusters` |
| `TestRegisteredTools_ReturnsNonEmptyList` | Init files actually populate the registry |
| `TestRegisteredTools_AllHaveNonEmptyName` | No empty schema names |
| `TestRegisteredTools_AllHaveDescription` | All tools are documented |
| `TestRegisteredTools_AllHaveHandler` | No nil handlers registered |
| `TestRegisteredTools_NoDuplicateNames` | Catches accidental double-registration |
| `TestRegisteredTools_CountMatchesRegistry` | `registeredTools()` slice consistency |
| `TestRegisteredTools_InputSchemaHasObjectType` | Schema structure validation |

These tests act as a safety net: any new tool added via the registry pattern will automatically be validated for completeness without needing per-tool test additions.

Fixes #257

---
*Filed by quality agent (ACMM L4/L6 — full mode)*