### PR TITLE
[quality] fix: resolve 3 CI-blocking compilation errors in test files

### DIFF
--- a/pkg/deploy/mcp/tools_kubectl_handlers_test.go
+++ b/pkg/deploy/mcp/tools_kubectl_handlers_test.go
@@ -197,10 +197,8 @@ func TestDeleteResourceInClusterUnsupportedKind(t *testing.T) {
 	result, err := server.deleteResourceInCluster(context.Background(), nil, "alpha", "Widget", "my-widget", "default", false)
 	require.NoError(t, err)
 
-	dr, ok := result.(DeleteResult)
-	require.True(t, ok)
-	assert.Equal(t, "failed", dr.Status)
-	assert.Contains(t, dr.Message, "Unsupported resource kind")
+	assert.Equal(t, "failed", result.Status)
+	assert.Contains(t, result.Message, "Unsupported resource kind")
 }
 
 func TestDeleteResourceInClusterDryRun(t *testing.T) {
@@ -209,9 +207,7 @@ func TestDeleteResourceInClusterDryRun(t *testing.T) {
 	result, err := server.deleteResourceInCluster(context.Background(), nil, "alpha", "Pod", "my-pod", "default", true)
 	require.NoError(t, err)
 
-	dr, ok := result.(DeleteResult)
-	require.True(t, ok)
-	assert.Equal(t, "would-delete", dr.Status)
+	assert.Equal(t, "would-delete", result.Status)
 }
 
 func TestApplyManifestDynamicDryRun(t *testing.T) {

--- a/pkg/mcp/server/upgrades_test.go
+++ b/pkg/mcp/server/upgrades_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bytes"
 	"compress/gzip"
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -233,24 +232,6 @@ func TestToolGetUpgradePrerequisites_NotReadyNode(t *testing.T) {
 	text := result.Content[0].Text
 	if !strings.Contains(text, "not ready") || !strings.Contains(text, "bad-node") {
 		t.Fatalf("expected not-ready node message, got: %s", text)
-	}
-}
-
-// --- toolGetUpgradeStatus ---
-
-func TestToolGetUpgradeStatus_ClientError(t *testing.T) {
-	server := &Server{
-		discoverer: stubDiscoverer{},
-		clientFactory: func(clusterName string) (kubernetes.Interface, error) {
-			return nil, errors.New("unreachable")
-		},
-	}
-	result, rpcErr := callTool(t, server, "get_upgrade_status", map[string]interface{}{"cluster": "test"})
-	if rpcErr != nil {
-		t.Fatalf("unexpected RPC error: %v", rpcErr)
-	}
-	if !result.IsError {
-		t.Fatalf("expected tool error")
 	}
 }
 


### PR DESCRIPTION
## Test Improvement

Fixes 3 pre-existing compilation errors in test files that block CI on any PR touching `pkg/mcp/server` or `pkg/deploy/mcp`.

### Changes

1. **`pkg/mcp/server/upgrades_test.go`**:
   - Removed unused `"context"` import
   - Removed duplicate `TestToolGetUpgradeStatus_ClientError` (also declared in `upgrades_coverage_test.go`)
   - Removed orphan section comment and stray closing brace left behind

2. **`pkg/deploy/mcp/tools_kubectl_handlers_test.go`**:
   - Fixed invalid type assertions `result.(DeleteResult)` — `deleteResourceInCluster` returns `DeleteResult` directly (a struct), not an interface, so type assertion is invalid. Replaced with direct field access.

### Impact

Unblocks CI for PR #258 and any future PRs in these packages.

Fixes #259

---
*Filed by quality agent (ACMM L4/L6 — full mode)*