### PR TITLE
feat: add MCP Registry submission infrastructure

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,70 @@
+name: Publish Docker Image to GHCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to build from (e.g. v0.9.0)'
+        required: true
+        type: string
+
+permissions: read-all
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: kubestellar/kubestellar-mcp
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+
+      - name: Determine version
+        id: version
+        run: |
+          TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          # Strip 'v' prefix for Docker tag
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }}
+            type=raw,value=latest,enable=${{ !contains(steps.version.outputs.tag, 'nightly') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN apk add --no-cache ca-certificates \
 
 COPY --from=builder /kubestellar-ops /usr/local/bin/kubestellar-ops
 
+# MCP Registry ownership verification label
+# See: https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/package-types.mdx
+LABEL io.modelcontextprotocol.server.name="io.github.kubestellar/kubestellar-mcp"
+
 USER nonroot:nonroot
 
 ENTRYPOINT ["kubestellar-ops", "--mcp-server"]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.kubestellar/kubestellar-mcp",
+  "title": "KubeStellar MCP",
+  "description": "AI-powered multi-cluster Kubernetes diagnostics, RBAC analysis, security checks, and app-centric deployment via MCP",
+  "repository": {
+    "url": "https://github.com/kubestellar/kubestellar-mcp",
+    "source": "github"
+  },
+  "version": "0.9.0",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/kubestellar/kubestellar-mcp:0.9.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "Path to kubeconfig file for cluster access",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "name": "KUBECONFIG"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the required artifacts for publishing kubestellar-mcp to the [official MCP Registry](https://registry.modelcontextprotocol.io/):

- **Dockerfile**: Added `io.modelcontextprotocol.server.name` OCI label for ownership verification
- **server.json**: MCP Registry metadata file for use with `mcp-publisher` CLI
- **ghcr-publish.yml**: GitHub Actions workflow to publish multi-arch Docker images to `ghcr.io/kubestellar/kubestellar-mcp` on release events

### Context

The `modelcontextprotocol/servers` repo [no longer accepts third-party server listings](https://github.com/modelcontextprotocol/servers/blob/main/CONTRIBUTING.md) — the community list has been retired in favor of the MCP Registry. The official path is now:

1. Publish a package (npm, PyPI, OCI, etc.) with a verification marker
2. Create a `server.json` with server metadata
3. Run `mcp-publisher publish` to register

This PR sets up the OCI path since kubestellar-mcp is a Go binary with an existing Dockerfile.

### Remaining steps after merge

1. Trigger GHCR publish for v0.9.0 (or next release)
2. Run `mcp-publisher login github && mcp-publisher publish` to register with the MCP Registry
3. Submit to [glama.ai](https://glama.ai/mcp/servers/submit) via web form (manual)

Fixes #209