### PR TITLE
🌱 Sync workflows from kubestellar/infra

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,4 +9,5 @@ permissions:
 
 jobs:
   label:
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
+    secrets: inherit

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,18 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   ai-fix:
-    permissions:
-      contents: write        # create branch and commit when applying Copilot fix
-      issues: write          # comment on the issue being fixed
-      pull-requests: write   # open the fix PR
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   assignment-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,7 +10,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions: {}
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  statuses: write
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -18,14 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      issues: write
-      pull-requests: read
-      statuses: write
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions: read-all  # reusable workflow inherits its own permissions
-
 jobs:
   copilot-dco:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,4 +10,5 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
+    secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,15 +6,12 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   greet:
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,4 +11,5 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,13 +4,11 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions: {}
+permissions:
+  checks: write
+  pull-requests: read
 
 jobs:
   verify:
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      checks: write
-      pull-requests: read
-      packages: read
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@2cdb7c22649c4e5cd36edc2d2fc57de96949e7a9
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,13 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions: {}  # deny all at top level; each job declares what it needs
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+  id-token: write
 
 jobs:
   analysis:
-    permissions:
-      security-events: write
-      contents: read
-      actions: read
-      id-token: write
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4  # main
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,4 +10,5 @@ permissions:
 
 jobs:
   stale:
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
+    secrets: inherit


### PR DESCRIPTION
This PR syncs the caller workflows from `kubestellar/infra`.

These workflows call reusable workflows from `kubestellar/infra`:

**Standard Workflows:**
- `add-help-wanted.yml` - Add help-wanted label to issues
- `assignment-helper.yml` - Handle issue assignments
- `feedback.yml` - Collect feedback
- `greetings.yml` - Welcome new contributors
- `label-helper.yml` - Manage labels
- `pr-verifier.yml` - Verify PR contents
- `pr-verify-title.yml` - Verify PR title format
- `scorecard.yml` - Security scorecard
- `stale.yml` - Mark stale issues/PRs

**Agentic Workflows (Copilot Integration):**
- `ai-fix.yml` - Assign Copilot to issues with `ai-fix-requested` label
- `copilot-automation.yml` - Automate Copilot PR processing (DCO, labels)
- `copilot-dco.yml` - Override DCO for Copilot PRs

Auto-generated by workflow sync