### PR TITLE
fix: use bin/"name" syntax in Homebrew formula test blocks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,7 +92,7 @@ brews:
     install: |
       bin.install "kubestellar-ops"
     test: |
-      system "#{bin}/kubestellar-ops", "version"
+      system bin/"kubestellar-ops", "version"
 
   - name: kubestellar-deploy
     ids:
@@ -108,4 +108,4 @@ brews:
     install: |
       bin.install "kubestellar-deploy"
     test: |
-      system "#{bin}/kubestellar-deploy", "version"
+      system bin/"kubestellar-deploy", "version"


### PR DESCRIPTION
Fixes kubestellar/homebrew-tap#107

## Problem

The Homebrew CI workflow in `kubestellar/homebrew-tap` is failing with `brew audit --strict` errors every time nightly builds run. The root cause is in this repository's GoReleaser configuration.

## Root Cause

The `.goreleaser.yaml` file generates Homebrew formulas with **incorrect test block syntax**:

```ruby
test do
  system "#{bin}/kubestellar-ops", "version"
end
```

Homebrew's strict audit requires the `bin/"name"` operator syntax instead of string interpolation `#{bin}/name`:

```ruby
test do
  system bin/"kubestellar-ops", "version"
end
```

Every nightly GoReleaser run overwrites the formulas in `homebrew-tap` with templates from this repo, reintroducing the syntax error even after manual fixes (see kubestellar/homebrew-tap#97).

## Changes

Fixed `.goreleaser.yaml` test blocks for both formulas:
- `kubestellar-ops`: Changed `system "#{bin}/kubestellar-ops", "version"` → `system bin/"kubestellar-ops", "version"`
- `kubestellar-deploy`: Changed `system "#{bin}/kubestellar-deploy", "version"` → `system bin/"kubestellar-deploy", "version"`

## Impact

✅ All future GoReleaser-generated formulas will pass `brew audit --strict`
✅ Homebrew CI in `homebrew-tap` will stop failing on nightly builds
✅ No functional changes — only syntax correction

## Testing

After this PR merges, the next nightly build will:
1. Generate formulas with correct syntax
2. Push them to `homebrew-tap`
3. Pass the `brew audit --strict` step in the Homebrew CI workflow

---

**Note:** This only fixes the **template source**. The formulas currently in `homebrew-tap` still have the old syntax and will be overwritten by the next nightly run.