### PR TITLE
ci: add MCP Registry publish workflow

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install mcp-publisher
         run: |

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,27 @@
+name: Publish to MCP Registry
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server metadata
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## Summary

Adds a manual GitHub Actions workflow to publish the existing `server.json` metadata to the official MCP Registry using GitHub OIDC.

This helps make `kubestellar-mcp` discoverable through the current MCP Registry flow. The old `modelcontextprotocol/servers` README list no longer accepts third-party server PRs and now points publishers to the registry instead.

## Related issue(s)

Fixes https://github.com/kubestellar/kubestellar/issues/3810
## Testing

- Ran `git diff --check -- .github/workflows/publish-mcp-registry.yml`
- Could not run `mcp-publisher` locally because Go/mcp-publisher is not installed in this environment