### PR TITLE
[scanner] fix: harden workflow security (greetings + pr-verifier)

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -14,4 +14,3 @@ permissions:
 jobs:
   greet:
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
-    secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -11,4 +11,3 @@ permissions:
 jobs:
   verify:
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
-    secrets: inherit


### PR DESCRIPTION
Fixes #337, Fixes #338

Hardens pull_request_target workflows by removing unnecessary secrets exposure.

- **greetings.yml**: Remove `secrets: inherit`
- **pr-verifier.yml**: Remove `secrets: inherit`

Both workflows only require `github.token`, which is provided automatically.