### PR TITLE
[scanner] fix: add unit tests for MCP tool registry files

### DIFF
--- a/pkg/mcp/server/tools_cluster_registry_test.go
+++ b/pkg/mcp/server/tools_cluster_registry_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterToolRegistry_AllToolsRegistered(t *testing.T) {
+	expectedTools := []string{
+		"list_clusters",
+		"get_cluster_health",
+	}
+
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	for _, name := range expectedTools {
+		tool, ok := registered[name]
+		require.True(t, ok, "expected cluster tool %q to be registered", name)
+		assert.NotEmpty(t, tool.Description, "tool %q should have a description", name)
+	}
+}
+
+func TestClusterToolRegistry_ToolCount(t *testing.T) {
+	expectedCount := 2
+	clusterTools := 0
+	for _, td := range toolRegistry {
+		switch td.Schema.Name {
+		case "list_clusters", "get_cluster_health":
+			clusterTools++
+		}
+	}
+	assert.Equal(t, expectedCount, clusterTools, "Cluster registry should have exactly %d tools", expectedCount)
+}
+
+func TestClusterToolRegistry_EnumFields(t *testing.T) {
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	tool, ok := registered["list_clusters"]
+	require.True(t, ok, "list_clusters should be registered")
+
+	source, exists := tool.InputSchema.Properties["source"]
+	require.True(t, exists, "source property should exist")
+	assert.NotEmpty(t, source.Enum, "source should have enum values")
+	assert.ElementsMatch(t, []string{"all", "kubeconfig", "kubestellar"}, source.Enum)
+}

--- a/pkg/mcp/server/tools_drift_registry_test.go
+++ b/pkg/mcp/server/tools_drift_registry_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDriftToolRegistry_AllToolsRegistered(t *testing.T) {
+	expectedTools := []string{
+		"detect_drift",
+	}
+
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	for _, name := range expectedTools {
+		tool, ok := registered[name]
+		require.True(t, ok, "expected drift tool %q to be registered", name)
+		assert.NotEmpty(t, tool.Description, "tool %q should have a description", name)
+	}
+}
+
+func TestDriftToolRegistry_ToolCount(t *testing.T) {
+	expectedCount := 1
+	driftTools := 0
+	for _, td := range toolRegistry {
+		if td.Schema.Name == "detect_drift" {
+			driftTools++
+		}
+	}
+	assert.Equal(t, expectedCount, driftTools, "Drift registry should have exactly %d tool", expectedCount)
+}
+
+func TestDriftToolRegistry_RequiredFields(t *testing.T) {
+	requiredFields := map[string][]string{
+		"detect_drift": {"repo_url"},
+	}
+
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	for toolName, expectedRequired := range requiredFields {
+		tool, ok := registered[toolName]
+		require.True(t, ok, "tool %q should be registered", toolName)
+		assert.ElementsMatch(t, expectedRequired, tool.InputSchema.Required,
+			"tool %q should have required fields: %v", toolName, expectedRequired)
+	}
+}
+
+func TestDriftToolRegistry_StringProperties(t *testing.T) {
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	tool, ok := registered["detect_drift"]
+	require.True(t, ok, "detect_drift should be registered")
+
+	expectedStringProps := []string{"repo_url", "path", "branch", "cluster", "namespace"}
+	for _, propName := range expectedStringProps {
+		prop, exists := tool.InputSchema.Properties[propName]
+		require.True(t, exists, "%q property should exist", propName)
+		assert.Equal(t, "string", prop.Type, "%q should be string type", propName)
+	}
+}

--- a/pkg/mcp/server/tools_policy_registry_test.go
+++ b/pkg/mcp/server/tools_policy_registry_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyToolRegistry_AllToolsRegistered(t *testing.T) {
+	expectedTools := []string{
+		"check_gatekeeper",
+		"get_ownership_policy_status",
+		"list_ownership_violations",
+		"install_ownership_policy",
+		"set_ownership_policy_mode",
+		"uninstall_ownership_policy",
+	}
+
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	for _, name := range expectedTools {
+		tool, ok := registered[name]
+		require.True(t, ok, "expected policy tool %q to be registered", name)
+		assert.NotEmpty(t, tool.Description, "tool %q should have a description", name)
+	}
+}
+
+func TestPolicyToolRegistry_ToolCount(t *testing.T) {
+	expectedCount := 6
+	policyTools := 0
+	for _, td := range toolRegistry {
+		switch td.Schema.Name {
+		case "check_gatekeeper", "get_ownership_policy_status",
+			"list_ownership_violations", "install_ownership_policy",
+			"set_ownership_policy_mode", "uninstall_ownership_policy":
+			policyTools++
+		}
+	}
+	assert.Equal(t, expectedCount, policyTools, "Policy registry should have exactly %d tools", expectedCount)
+}
+
+func TestPolicyToolRegistry_RequiredFields(t *testing.T) {
+	requiredFields := map[string][]string{
+		"set_ownership_policy_mode": {"mode"},
+	}
+
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	for toolName, expectedRequired := range requiredFields {
+		tool, ok := registered[toolName]
+		require.True(t, ok, "tool %q should be registered", toolName)
+		assert.ElementsMatch(t, expectedRequired, tool.InputSchema.Required,
+			"tool %q should have required fields: %v", toolName, expectedRequired)
+	}
+}
+
+func TestPolicyToolRegistry_EnumFields(t *testing.T) {
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	testCases := []struct {
+		toolName     string
+		propertyName string
+		expectedEnum []string
+	}{
+		{
+			toolName:     "install_ownership_policy",
+			propertyName: "mode",
+			expectedEnum: []string{"dryrun", "warn", "enforce"},
+		},
+		{
+			toolName:     "set_ownership_policy_mode",
+			propertyName: "mode",
+			expectedEnum: []string{"dryrun", "warn", "enforce"},
+		},
+	}
+
+	for _, tc := range testCases {
+		tool, ok := registered[tc.toolName]
+		require.True(t, ok, "%q should be registered", tc.toolName)
+
+		prop, exists := tool.InputSchema.Properties[tc.propertyName]
+		require.True(t, exists, "%q property should exist in %q", tc.propertyName, tc.toolName)
+		assert.NotEmpty(t, prop.Enum, "%q.%q should have enum values", tc.toolName, tc.propertyName)
+		assert.ElementsMatch(t, tc.expectedEnum, prop.Enum)
+	}
+}

--- a/pkg/mcp/server/tools_rbac_registry_test.go
+++ b/pkg/mcp/server/tools_rbac_registry_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRBACToolRegistry_AllToolsRegistered(t *testing.T) {
+	expectedTools := []string{
+		"get_roles",
+		"get_cluster_roles",
+		"get_role_bindings",
+		"get_cluster_role_bindings",
+		"can_i",
+		"analyze_subject_permissions",
+		"describe_role",
+	}
+
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	for _, name := range expectedTools {
+		tool, ok := registered[name]
+		require.True(t, ok, "expected RBAC tool %q to be registered", name)
+		assert.NotEmpty(t, tool.Description, "tool %q should have a description", name)
+	}
+}
+
+func TestRBACToolRegistry_ToolCount(t *testing.T) {
+	expectedCount := 7
+	rbacTools := 0
+	for _, td := range toolRegistry {
+		switch td.Schema.Name {
+		case "get_roles", "get_cluster_roles", "get_role_bindings",
+			"get_cluster_role_bindings", "can_i", "analyze_subject_permissions",
+			"describe_role":
+			rbacTools++
+		}
+	}
+	assert.Equal(t, expectedCount, rbacTools, "RBAC registry should have exactly %d tools", expectedCount)
+}
+
+func TestRBACToolRegistry_RequiredFields(t *testing.T) {
+	requiredFields := map[string][]string{
+		"can_i":                       {"verb", "resource"},
+		"analyze_subject_permissions": {"subject_kind", "subject_name"},
+		"describe_role":               {"name"},
+	}
+
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	for toolName, expectedRequired := range requiredFields {
+		tool, ok := registered[toolName]
+		require.True(t, ok, "tool %q should be registered", toolName)
+		assert.ElementsMatch(t, expectedRequired, tool.InputSchema.Required,
+			"tool %q should have required fields: %v", toolName, expectedRequired)
+	}
+}
+
+func TestRBACToolRegistry_EnumFields(t *testing.T) {
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	tool, ok := registered["analyze_subject_permissions"]
+	require.True(t, ok, "analyze_subject_permissions should be registered")
+
+	subjectKind, exists := tool.InputSchema.Properties["subject_kind"]
+	require.True(t, exists, "subject_kind property should exist")
+	assert.NotEmpty(t, subjectKind.Enum, "subject_kind should have enum values")
+	assert.ElementsMatch(t, []string{"User", "Group", "ServiceAccount"}, subjectKind.Enum)
+}

--- a/pkg/mcp/server/tools_workloads_registry_test.go
+++ b/pkg/mcp/server/tools_workloads_registry_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkloadsToolRegistry_AllToolsRegistered(t *testing.T) {
+	expectedTools := []string{
+		"get_pods",
+		"get_deployments",
+		"get_services",
+		"get_nodes",
+		"get_events",
+		"describe_pod",
+		"get_pod_logs",
+		"find_pod_issues",
+		"find_deployment_issues",
+		"check_resource_limits",
+		"check_security_issues",
+		"analyze_namespace",
+		"get_warning_events",
+		"audit_kubeconfig",
+		"find_resource_owners",
+	}
+
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	for _, name := range expectedTools {
+		tool, ok := registered[name]
+		require.True(t, ok, "expected workloads tool %q to be registered", name)
+		assert.NotEmpty(t, tool.Description, "tool %q should have a description", name)
+	}
+}
+
+func TestWorkloadsToolRegistry_ToolCount(t *testing.T) {
+	expectedCount := 15
+	workloadTools := 0
+	for _, td := range toolRegistry {
+		switch td.Schema.Name {
+		case "get_pods", "get_deployments", "get_services", "get_nodes",
+			"get_events", "describe_pod", "get_pod_logs", "find_pod_issues",
+			"find_deployment_issues", "check_resource_limits",
+			"check_security_issues", "analyze_namespace", "get_warning_events",
+			"audit_kubeconfig", "find_resource_owners":
+			workloadTools++
+		}
+	}
+	assert.Equal(t, expectedCount, workloadTools, "Workloads registry should have exactly %d tools", expectedCount)
+}
+
+func TestWorkloadsToolRegistry_RequiredFields(t *testing.T) {
+	requiredFields := map[string][]string{
+		"describe_pod":         {"name"},
+		"get_pod_logs":         {"name"},
+		"analyze_namespace":    {"namespace"},
+		"find_resource_owners": {"namespace"},
+	}
+
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	for toolName, expectedRequired := range requiredFields {
+		tool, ok := registered[toolName]
+		require.True(t, ok, "tool %q should be registered", toolName)
+		assert.ElementsMatch(t, expectedRequired, tool.InputSchema.Required,
+			"tool %q should have required fields: %v", toolName, expectedRequired)
+	}
+}
+
+func TestWorkloadsToolRegistry_IntegerProperties(t *testing.T) {
+	registered := make(map[string]Tool)
+	for _, td := range toolRegistry {
+		registered[td.Schema.Name] = td.Schema
+	}
+
+	testCases := []struct {
+		toolName     string
+		propertyName string
+	}{
+		{"get_events", "limit"},
+		{"get_pod_logs", "tail_lines"},
+		{"get_warning_events", "limit"},
+		{"audit_kubeconfig", "timeout_seconds"},
+	}
+
+	for _, tc := range testCases {
+		tool, ok := registered[tc.toolName]
+		require.True(t, ok, "%q should be registered", tc.toolName)
+
+		prop, exists := tool.InputSchema.Properties[tc.propertyName]
+		require.True(t, exists, "%q property should exist in %q", tc.propertyName, tc.toolName)
+		assert.Equal(t, "integer", prop.Type, "%q.%q should be integer type", tc.toolName, tc.propertyName)
+	}
+}

--- a/pkg/mcp/tools/upgrades/register_test.go
+++ b/pkg/mcp/tools/upgrades/register_test.go
@@ -1,0 +1,84 @@
+package upgrades
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradesToolRegistry_AllToolsRegistered(t *testing.T) {
+	expectedTools := []string{
+		"detect_cluster_type",
+		"get_cluster_version_info",
+		"check_olm_operator_upgrades",
+		"check_helm_release_upgrades",
+		"get_upgrade_prerequisites",
+		"trigger_openshift_upgrade",
+		"get_upgrade_status",
+	}
+
+	tools := Tools()
+	registered := make(map[string]bool)
+	for _, td := range tools {
+		registered[td.Schema.Name] = true
+	}
+
+	for _, name := range expectedTools {
+		require.True(t, registered[name], "expected upgrades tool %q to be registered", name)
+	}
+
+	for _, td := range tools {
+		assert.NotEmpty(t, td.Schema.Description, "tool %q should have a description", td.Schema.Name)
+	}
+}
+
+func TestUpgradesToolRegistry_ToolCount(t *testing.T) {
+	expectedCount := 7
+	tools := Tools()
+	assert.Equal(t, expectedCount, len(tools), "Upgrades registry should have exactly %d tools", expectedCount)
+}
+
+func TestUpgradesToolRegistry_RequiredFields(t *testing.T) {
+	requiredFields := map[string][]string{
+		"trigger_openshift_upgrade": {"target_version", "confirm"},
+	}
+
+	tools := Tools()
+	registered := make(map[string]ToolDef)
+	for _, td := range tools {
+		registered[td.Schema.Name] = td
+	}
+
+	for toolName, expectedRequired := range requiredFields {
+		tool, ok := registered[toolName]
+		require.True(t, ok, "tool %q should be registered", toolName)
+		assert.ElementsMatch(t, expectedRequired, tool.Schema.InputSchema.Required,
+			"tool %q should have required fields: %v", toolName, expectedRequired)
+	}
+}
+
+func TestUpgradesToolRegistry_ConfirmationGating(t *testing.T) {
+	tools := Tools()
+	registered := make(map[string]ToolDef)
+	for _, td := range tools {
+		registered[td.Schema.Name] = td
+	}
+
+	tool, ok := registered["trigger_openshift_upgrade"]
+	require.True(t, ok, "trigger_openshift_upgrade should be registered")
+
+	confirm, exists := tool.Schema.InputSchema.Properties["confirm"]
+	require.True(t, exists, "confirm property should exist")
+	assert.Equal(t, "string", confirm.Type, "confirm should be string type")
+	assert.Contains(t, confirm.Description, "yes-upgrade-now", "confirm description should mention the required value")
+
+	assert.Contains(t, tool.Schema.Description, "REQUIRES CONFIRMATION", "tool description should indicate confirmation requirement")
+}
+
+func TestUpgradesToolRegistry_AllHandlersExist(t *testing.T) {
+	tools := Tools()
+	for _, td := range tools {
+		assert.NotNil(t, td.Handler, "tool %q should have a handler", td.Schema.Name)
+	}
+}


### PR DESCRIPTION
Fixes #359

## Test Improvement

Adds registry-level unit tests for all MCP tool registry files:
- RBAC tools registry
- Policy tools registry
- Workloads tools registry
- Drift detection tools registry
- Cluster tools registry
- Upgrades tools registry

Each test verifies:
- All expected tools are registered by name
- Input schemas have correct required fields
- Tool descriptions are non-empty
- Tool count matches expectations

---
*Filed by scanner agent*