### PR TITLE
🐛 fix: validate namespace arguments to prevent prompt injection (fixes #377)

### DIFF
--- a/pkg/deploy/mcp/tools_app.go
+++ b/pkg/deploy/mcp/tools_app.go
@@ -10,13 +10,13 @@ import (
 	"sync"
 	"time"
 
+	server "github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubestellar/kubestellar-mcp/pkg/ai/claude"
-	server "github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
 )
 
 // AppInstance represents an app instance in a cluster
@@ -106,8 +106,10 @@ func (s *Server) findAppInCluster(ctx context.Context, client *kubernetes.Client
 		ns = metav1.NamespaceAll
 	}
 
-	if !safeName(ns) {
-		return nil, fmt.Errorf("bad namespace")
+	if ns != "" {
+		if err := server.ValidateNamespace(ns); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	// Search Deployments
@@ -305,8 +307,10 @@ func (s *Server) getLogsFromCluster(ctx context.Context, client *kubernetes.Clie
 		ns = metav1.NamespaceAll
 	}
 
-	if !safeName(ns) {
-		return nil, fmt.Errorf("bad namespace")
+	if ns != "" {
+		if err := server.ValidateNamespace(ns); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	// Find pods matching app
@@ -431,17 +435,4 @@ func getDaemonSetStatus(d *appsv1.DaemonSet) string {
 	return "failed"
 }
 
-func safeName(name string) bool {
-	if len(name) == 0 || len(name) > 253 {
-		return false
-	}
-	for i, r := range name {
-		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.') {
-			return false
-		}
-		if i == 0 && r == '.' {
-			return false
-		}
-	}
-	return name[len(name)-1] != '.'
-}
+

--- a/pkg/deploy/mcp/tools_app.go
+++ b/pkg/deploy/mcp/tools_app.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubestellar/kubestellar-mcp/pkg/ai/claude"
+	server "github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
 )
 
 // AppInstance represents an app instance in a cluster
@@ -54,7 +55,7 @@ type LogEntry struct {
 func (s *Server) handleGetAppInstances(ctx context.Context, args json.RawMessage) (interface{}, error) {
 	var params struct {
 		App       string `json:"app"`
-		Namespace string `json:"namespace"`
+		Namespace string `json:"namespace,omitempty"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
@@ -63,8 +64,13 @@ func (s *Server) handleGetAppInstances(ctx context.Context, args json.RawMessage
 	if err := claude.ValidateK8sName(params.App); err != nil {
 		return nil, fmt.Errorf("invalid app name: %w", err)
 	}
-	if err := claude.ValidateK8sNamespace(params.Namespace); err != nil {
-		return nil, fmt.Errorf("invalid namespace: %w", err)
+	if params.Namespace != "" {
+		if err := claude.ValidateK8sNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	results, err := s.executor.Execute(ctx, "", func(ctx context.Context, client *kubernetes.Clientset, clusterName string) (interface{}, error) {
@@ -98,6 +104,10 @@ func (s *Server) findAppInCluster(ctx context.Context, client *kubernetes.Client
 	ns := namespace
 	if ns == "" {
 		ns = metav1.NamespaceAll
+	}
+
+	if !safeName(ns) {
+		return nil, fmt.Errorf("bad namespace")
 	}
 
 	// Search Deployments
@@ -161,7 +171,7 @@ func (s *Server) findAppInCluster(ctx context.Context, client *kubernetes.Client
 func (s *Server) handleGetAppStatus(ctx context.Context, args json.RawMessage) (interface{}, error) {
 	var params struct {
 		App       string `json:"app"`
-		Namespace string `json:"namespace"`
+		Namespace string `json:"namespace,omitempty"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
@@ -170,8 +180,13 @@ func (s *Server) handleGetAppStatus(ctx context.Context, args json.RawMessage) (
 	if err := claude.ValidateK8sName(params.App); err != nil {
 		return nil, fmt.Errorf("invalid app name: %w", err)
 	}
-	if err := claude.ValidateK8sNamespace(params.Namespace); err != nil {
-		return nil, fmt.Errorf("invalid namespace: %w", err)
+	if params.Namespace != "" {
+		if err := claude.ValidateK8sNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	results, err := s.executor.Execute(ctx, "", func(ctx context.Context, client *kubernetes.Clientset, clusterName string) (interface{}, error) {
@@ -245,8 +260,13 @@ func (s *Server) handleGetAppLogs(ctx context.Context, args json.RawMessage) (in
 	if err := claude.ValidateK8sName(params.App); err != nil {
 		return nil, fmt.Errorf("invalid app name: %w", err)
 	}
-	if err := claude.ValidateK8sNamespace(params.Namespace); err != nil {
-		return nil, fmt.Errorf("invalid namespace: %w", err)
+	if params.Namespace != "" {
+		if err := claude.ValidateK8sNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	if params.Tail == 0 {
@@ -283,6 +303,10 @@ func (s *Server) getLogsFromCluster(ctx context.Context, client *kubernetes.Clie
 	ns := namespace
 	if ns == "" {
 		ns = metav1.NamespaceAll
+	}
+
+	if !safeName(ns) {
+		return nil, fmt.Errorf("bad namespace")
 	}
 
 	// Find pods matching app
@@ -405,4 +429,19 @@ func getDaemonSetStatus(d *appsv1.DaemonSet) string {
 		return "degraded"
 	}
 	return "failed"
+}
+
+func safeName(name string) bool {
+	if len(name) == 0 || len(name) > 253 {
+		return false
+	}
+	for i, r := range name {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.') {
+			return false
+		}
+		if i == 0 && r == '.' {
+			return false
+		}
+	}
+	return name[len(name)-1] != '.'
 }

--- a/pkg/deploy/mcp/tools_deploy.go
+++ b/pkg/deploy/mcp/tools_deploy.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	server "github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
 	"github.com/kubestellar/kubestellar-mcp/pkg/gitops"
 	"github.com/kubestellar/kubestellar-mcp/pkg/multicluster"
 	appsv1 "k8s.io/api/apps/v1"
@@ -194,6 +195,16 @@ func (s *Server) applyManifest(ctx context.Context, client kubernetes.Interface,
 			namespace, _ := metadata["namespace"].(string)
 			if namespace == "" {
 				namespace = "default"
+			}
+
+			// Validate namespace from manifest to prevent access to system namespaces (#377).
+			if namespace != "" {
+				if err := server.ValidateNamespace(namespace); err != nil {
+					return []DeployResult{{
+						Cluster: clusterName, Status: "failed",
+						Message: fmt.Sprintf("invalid namespace in manifest: %v", err),
+					}}, nil
+				}
 			}
 
 			resourceName := fmt.Sprintf("%s/%s", kind, name)
@@ -416,6 +427,13 @@ func (s *Server) handleScaleApp(ctx context.Context, args json.RawMessage) (inte
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
+	// Validate namespace to prevent access to system namespaces (#377).
+	if params.Namespace != "" {
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
+	}
+
 	// Get target clusters
 	targetClusters := params.Clusters
 	if len(targetClusters) == 0 {
@@ -500,6 +518,13 @@ func (s *Server) handlePatchApp(ctx context.Context, args json.RawMessage) (inte
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+
+	// Validate namespace to prevent access to system namespaces (#377).
+	if params.Namespace != "" {
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	patchType := types.StrategicMergePatchType

--- a/pkg/deploy/mcp/tools_gitops.go
+++ b/pkg/deploy/mcp/tools_gitops.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	server "github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubestellar/kubestellar-mcp/pkg/gitops"
@@ -170,6 +171,13 @@ func (s *Server) handleSyncFromGit(ctx context.Context, args json.RawMessage) (i
 
 	if params.Repo == "" {
 		return nil, fmt.Errorf("repo is required")
+	}
+
+	// Validate namespace override to prevent access to system namespaces (#377).
+	if params.Namespace != "" {
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	source := gitops.ManifestSource{

--- a/pkg/deploy/mcp/tools_helm.go
+++ b/pkg/deploy/mcp/tools_helm.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+
+	server "github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
 )
 
 var (
@@ -292,6 +294,11 @@ func (s *Server) handleHelmInstall(ctx context.Context, args json.RawMessage) (i
 		params.Namespace = "default"
 	}
 
+	// Validate namespace to prevent access to system namespaces (#377).
+	if err := server.ValidateNamespace(params.Namespace); err != nil {
+		return nil, fmt.Errorf("invalid namespace: %w", err)
+	}
+
 	// Validate chart ref to prevent local filesystem access and OCI SSRF (see #246).
 	if err := validateHelmChartRef(params.Chart); err != nil {
 		return nil, fmt.Errorf("invalid chart ref: %w", err)
@@ -489,6 +496,11 @@ func (s *Server) handleHelmUninstall(ctx context.Context, args json.RawMessage) 
 		params.Namespace = "default"
 	}
 
+	// Validate namespace to prevent access to system namespaces (#377).
+	if err := server.ValidateNamespace(params.Namespace); err != nil {
+		return nil, fmt.Errorf("invalid namespace: %w", err)
+	}
+
 	// Validate identifiers against Kubernetes naming rules to prevent flag injection (#269).
 	if err := validateHelmIdentifier("release_name", params.ReleaseName); err != nil {
 		return nil, err
@@ -608,6 +620,13 @@ func (s *Server) handleHelmList(ctx context.Context, args json.RawMessage) (inte
 		return nil, err
 	}
 
+	// Validate namespace to prevent access to system namespaces (#377).
+	if params.Namespace != "" {
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
+	}
+
 	// Validate filter to prevent flag injection (#344).
 	if params.Filter != "" && strings.HasPrefix(params.Filter, "-") {
 		return nil, fmt.Errorf("filter %q must not begin with '-' (possible flag injection)", params.Filter)
@@ -704,6 +723,11 @@ func (s *Server) handleHelmRollback(ctx context.Context, args json.RawMessage) (
 
 	if params.Namespace == "" {
 		params.Namespace = "default"
+	}
+
+	// Validate namespace to prevent access to system namespaces (#377).
+	if err := server.ValidateNamespace(params.Namespace); err != nil {
+		return nil, fmt.Errorf("invalid namespace: %w", err)
 	}
 
 	// Validate identifiers against Kubernetes naming rules to prevent flag injection (#269).

--- a/pkg/deploy/mcp/tools_kubectl.go
+++ b/pkg/deploy/mcp/tools_kubectl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	server "github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,6 +50,13 @@ func (s *Server) handleDeleteResource(ctx context.Context, args json.RawMessage)
 
 	if params.Kind == "" || params.Name == "" {
 		return nil, fmt.Errorf("kind and name are required")
+	}
+
+	// Validate namespace to prevent access to system namespaces (#377).
+	if params.Namespace != "" {
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	// Get target clusters
@@ -279,6 +287,14 @@ func (s *Server) applyManifestDynamic(ctx context.Context, clusterName, manifest
 		namespace := obj.GetNamespace()
 		if namespace == "" {
 			namespace = "default"
+		}
+
+		// Validate namespace from manifest to prevent access to system namespaces (#377).
+		if namespace != "" {
+			if err := server.ValidateNamespace(namespace); err != nil {
+				return []ApplyResult{{Cluster: clusterName, Status: "failed",
+					Message: fmt.Sprintf("invalid namespace in manifest: %v", err)}}, nil
+			}
 		}
 
 		result := ApplyResult{

--- a/pkg/deploy/mcp/tools_kustomize.go
+++ b/pkg/deploy/mcp/tools_kustomize.go
@@ -131,6 +131,10 @@ func (s *Server) handleKustomizeBuild(ctx context.Context, args json.RawMessage)
 	}, nil
 }
 
+// TODO(#377): Namespace validation for kustomize is deferred because namespace is
+// embedded in unstructured YAML output from `kustomize build`. Parsing the full
+// manifest to extract namespace(s) would require non-trivial YAML parsing.
+// Consider adding validation in a follow-up PR if needed.
 // handleKustomizeApply applies kustomize output to clusters
 func (s *Server) handleKustomizeApply(ctx context.Context, args json.RawMessage) (interface{}, error) {
 	var params struct {
@@ -240,6 +244,7 @@ func (s *Server) applyKustomize(ctx context.Context, cluster, path, manifest str
 	return result
 }
 
+// TODO(#377): Namespace validation for kustomize is deferred — see handleKustomizeApply.
 // handleKustomizeDelete deletes resources from kustomize output
 func (s *Server) handleKustomizeDelete(ctx context.Context, args json.RawMessage) (interface{}, error) {
 	var params struct {

--- a/pkg/deploy/mcp/tools_labels.go
+++ b/pkg/deploy/mcp/tools_labels.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	server "github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -41,6 +42,13 @@ func (s *Server) handleAddLabels(ctx context.Context, args json.RawMessage) (int
 	}
 	if len(params.Labels) == 0 {
 		return nil, fmt.Errorf("labels are required")
+	}
+
+	// Validate namespace to prevent access to system namespaces (#377).
+	if params.Namespace != "" {
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	// Get target clusters
@@ -179,6 +187,13 @@ func (s *Server) handleRemoveLabels(ctx context.Context, args json.RawMessage) (
 	}
 	if len(params.Labels) == 0 {
 		return nil, fmt.Errorf("labels are required")
+	}
+
+	// Validate namespace to prevent access to system namespaces (#377).
+	if params.Namespace != "" {
+		if err := server.ValidateNamespace(params.Namespace); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
 	}
 
 	// Get target clusters

--- a/pkg/deploy/mcp/tools_namespace_test.go
+++ b/pkg/deploy/mcp/tools_namespace_test.go
@@ -1,0 +1,29 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	server "github.com/kubestellar/kubestellar-mcp/pkg/mcp/server"
+)
+
+// TestValidateNamespace_Blocked is a smoke-test that verifies the deploy
+// server's ValidateNamespace integration rejects a blocked system namespace.
+func TestValidateNamespace_Blocked(t *testing.T) {
+	err := server.ValidateNamespace("kube-system")
+	if err == nil {
+		t.Fatal("expected error for blocked namespace kube-system, got nil")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("error message %q does not contain %q", err.Error(), "not allowed")
+	}
+}
+
+// TestValidateNamespace_Allowed is a smoke-test that verifies the deploy
+// server's ValidateNamespace integration allows a safe user namespace.
+func TestValidateNamespace_Allowed(t *testing.T) {
+	err := server.ValidateNamespace("my-app")
+	if err != nil {
+		t.Fatalf("expected no error for allowed namespace my-app, got %v", err)
+	}
+}

--- a/pkg/mcp/server/diagnostics.go
+++ b/pkg/mcp/server/diagnostics.go
@@ -15,7 +15,10 @@ import (
 
 func (s *Server) toolFindPodIssues(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	includeCompleted := args["include_completed"] == "true"
 
 	client, err := s.getClientForCluster(cluster)
@@ -114,7 +117,10 @@ func (s *Server) toolFindPodIssues(ctx context.Context, args map[string]interfac
 
 func (s *Server) toolFindDeploymentIssues(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 
 	client, err := s.getClientForCluster(cluster)
 	if err != nil {
@@ -213,7 +219,10 @@ func (s *Server) toolFindDeploymentIssues(ctx context.Context, args map[string]i
 
 func (s *Server) toolCheckResourceLimits(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 
 	client, err := s.getClientForCluster(cluster)
 	if err != nil {
@@ -283,7 +292,10 @@ func (s *Server) toolCheckResourceLimits(ctx context.Context, args map[string]in
 
 func (s *Server) toolCheckSecurityIssues(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 
 	client, err := s.getClientForCluster(cluster)
 	if err != nil {
@@ -375,8 +387,10 @@ func (s *Server) toolCheckSecurityIssues(ctx context.Context, args map[string]in
 
 func (s *Server) toolAnalyzeNamespace(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
-
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	if namespace == "" {
 		return "namespace is required", true
 	}
@@ -511,7 +525,10 @@ func (s *Server) toolAnalyzeNamespace(ctx context.Context, args map[string]inter
 
 func (s *Server) toolGetWarningEvents(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	involvedObject, _ := args["involved_object"].(string)
 	limit := int64(50)
 	if v, ok := args["limit"].(float64); ok {

--- a/pkg/mcp/server/namespace_validator.go
+++ b/pkg/mcp/server/namespace_validator.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+)
+
+// blockedExact is a set of system namespace names that are not allowed for
+// AI-driven operations regardless of the action being performed.
+// Using a blocklist (rather than an allowlist) ensures that user-defined
+// namespaces continue to work without an explicit registration step.
+var blockedExact = map[string]bool{
+	"kube-system":       true,
+	"kube-public":       true,
+	"kube-node-lease":   true,
+	"gatekeeper-system": true,
+	"openshift":         true,
+}
+
+// ValidateNamespace checks whether the supplied namespace is allowed for
+// AI-driven operations. An empty string (all-namespaces mode) is always
+// accepted. The blocklist match is exact/string-based (map lookup + prefix
+// check are case-sensitive). Kubernetes namespace names are constrained to
+// DNS-1123 labels (lowercase alphanumeric), so case collisions are unlikely.
+func ValidateNamespace(ns string) error {
+	if ns == "" {
+		return nil
+	}
+	if blockedExact[ns] {
+		return fmt.Errorf("access to system namespace %q is not allowed", ns)
+	}
+	if strings.HasPrefix(ns, "openshift-") {
+		return fmt.Errorf("access to system namespace %q is not allowed", ns)
+	}
+	return nil
+}
+
+// extractAndValidateNamespace pulls the "namespace" key from a tool argument
+// map and validates it. When the key is absent or the value is an empty
+// string, the call is allowed (all-namespaces mode) and ("", nil) is returned.
+// A non-string value is rejected with an error, preventing type-coercion
+// bypass of the namespace blocklist.
+func extractAndValidateNamespace(args map[string]interface{}) (string, error) {
+	raw, ok := args["namespace"]
+	if !ok {
+		return "", nil
+	}
+
+	ns, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("namespace must be a string, got %T", raw)
+	}
+
+	if err := ValidateNamespace(ns); err != nil {
+		return "", err
+	}
+
+	return ns, nil
+}

--- a/pkg/mcp/server/namespace_validator_test.go
+++ b/pkg/mcp/server/namespace_validator_test.go
@@ -1,0 +1,166 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestValidateNamespace_BlockedExact verifies that every namespace in the
+// blockedExact map is rejected by ValidateNamespace.
+func TestValidateNamespace_BlockedExact(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+	}{
+		{name: "kube-system", namespace: "kube-system"},
+		{name: "kube-public", namespace: "kube-public"},
+		{name: "kube-node-lease", namespace: "kube-node-lease"},
+		{name: "gatekeeper-system", namespace: "gatekeeper-system"},
+		{name: "openshift", namespace: "openshift"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNamespace(tt.namespace)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "not allowed")
+		})
+	}
+}
+
+// TestValidateNamespace_BlockedPrefix verifies that any namespace beginning
+// with "openshift-" is rejected.
+func TestValidateNamespace_BlockedPrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+	}{
+		{name: "openshift-ingress", namespace: "openshift-ingress"},
+		{name: "openshift-monitoring", namespace: "openshift-monitoring"},
+		{name: "openshift-api", namespace: "openshift-api"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNamespace(tt.namespace)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "not allowed")
+		})
+	}
+}
+
+// TestValidateNamespace_Allowed verifies that user-facing namespaces and the
+// empty string (all-namespaces mode) are accepted.
+func TestValidateNamespace_Allowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+	}{
+		{name: "empty (all-namespaces)", namespace: ""},
+		{name: "default", namespace: "default"},
+		{name: "my-app", namespace: "my-app"},
+		{name: "kube-flannel", namespace: "kube-flannel"},
+		{name: "istio-system", namespace: "istio-system"},
+		{name: "custom-ns", namespace: "custom-ns"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNamespace(tt.namespace)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestValidateNamespace_CaseSensitive asserts that the function is
+// case-sensitive: only the exact lower-case forms in the blocklist are
+// rejected, so mixed-case variants are allowed.
+func TestValidateNamespace_CaseSensitive(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+	}{
+		{name: "Kube-System mixed case", namespace: "Kube-System"},
+		{name: "KUBE-SYSTEM upper", namespace: "KUBE-SYSTEM"},
+		{name: "OPENSHIFT upper", namespace: "OPENSHIFT"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNamespace(tt.namespace)
+			assert.NoError(t, err, "namespace %q should not be blocked (case-sensitive)", tt.namespace)
+		})
+	}
+}
+
+// TestValidateNamespace_EdgeCases covers inputs that could be confused with
+// blocked namespaces but should be allowed.
+func TestValidateNamespace_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+	}{
+		{name: "kube without suffix", namespace: "kube"},
+		{name: "openshifted (not openshift- prefix)", namespace: "openshifted"},
+		{name: "dot", namespace: "."},
+		{name: "kube- prefix only", namespace: "kube-"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNamespace(tt.namespace)
+			assert.NoError(t, err, "namespace %q should be allowed", tt.namespace)
+		})
+	}
+}
+
+// TestExtractAndValidateNamespace exercises the helper that extracts and
+// validates the "namespace" key from a tool argument map.
+func TestExtractAndValidateNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      map[string]interface{}
+		wantNs    string
+		wantErr   bool
+		errExpect string
+	}{
+		{
+			name:    "blocked namespace kube-system",
+			args:    map[string]interface{}{"namespace": "kube-system"},
+			wantErr: true,
+		},
+		{
+			name:    "allowed namespace default",
+			args:    map[string]interface{}{"namespace": "default"},
+			wantNs:  "default",
+			wantErr: false,
+		},
+		{
+			name:    "key absent",
+			args:    map[string]interface{}{},
+			wantNs:  "",
+			wantErr: false,
+		},
+		{
+			name:    "namespace is integer, not string",
+			args:    map[string]interface{}{"namespace": 123},
+			wantErr: true,
+		},
+		{
+			name:    "empty string namespace",
+			args:    map[string]interface{}{"namespace": ""},
+			wantNs:  "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractAndValidateNamespace(tt.args)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errExpect != "" {
+					assert.Contains(t, err.Error(), tt.errExpect)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantNs, got)
+		})
+	}
+}

--- a/pkg/mcp/server/tools_policy.go
+++ b/pkg/mcp/server/tools_policy.go
@@ -193,7 +193,10 @@ func (s *Server) toolGetOwnershipPolicyStatus(ctx context.Context, args map[stri
 
 func (s *Server) toolListOwnershipViolations(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespaceFilter, _ := args["namespace"].(string)
+	namespaceFilter, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	limit := int64(50)
 	if v, ok := args["limit"].(float64); ok {
 		limit = int64(v)

--- a/pkg/mcp/server/tools_rbac.go
+++ b/pkg/mcp/server/tools_rbac.go
@@ -15,7 +15,10 @@ import (
 
 func (s *Server) toolGetRoles(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 
 	client, err := s.getClientForCluster(cluster)
 	if err != nil {
@@ -90,7 +93,10 @@ func (s *Server) toolGetClusterRoles(ctx context.Context, args map[string]interf
 
 func (s *Server) toolGetRoleBindings(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 
 	client, err := s.getClientForCluster(cluster)
 	if err != nil {
@@ -185,7 +191,10 @@ func (s *Server) toolCanI(ctx context.Context, args map[string]interface{}) (str
 	cluster, _ := args["cluster"].(string)
 	verb, _ := args["verb"].(string)
 	resource, _ := args["resource"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	subresource, _ := args["subresource"].(string)
 	name, _ := args["name"].(string)
 
@@ -244,7 +253,10 @@ func (s *Server) toolAnalyzeSubjectPermissions(ctx context.Context, args map[str
 	cluster, _ := args["cluster"].(string)
 	subjectKind, _ := args["subject_kind"].(string)
 	subjectName, _ := args["subject_name"].(string)
-	subjectNamespace, _ := args["namespace"].(string)
+	subjectNamespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 
 	if subjectKind == "" || subjectName == "" {
 		return "subject_kind and subject_name are required", true
@@ -337,7 +349,10 @@ func subjectMatches(subjects []rbacv1.Subject, kind, name, namespace string) boo
 func (s *Server) toolDescribeRole(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
 	name, _ := args["name"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 
 	if name == "" {
 		return "name is required", true
@@ -417,7 +432,10 @@ func (s *Server) toolDescribeRole(ctx context.Context, args map[string]interface
 
 func (s *Server) toolFindResourceOwners(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	resourceType, _ := args["resource_type"].(string)
 
 	if namespace == "" {

--- a/pkg/mcp/server/tools_workloads.go
+++ b/pkg/mcp/server/tools_workloads.go
@@ -12,7 +12,10 @@ import (
 
 func (s *Server) toolGetPods(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	labelSelector, _ := args["label_selector"].(string)
 
 	client, err := s.getClientForCluster(cluster)
@@ -70,7 +73,10 @@ func (s *Server) toolGetPods(ctx context.Context, args map[string]interface{}) (
 
 func (s *Server) toolGetDeployments(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 
 	client, err := s.getClientForCluster(cluster)
 	if err != nil {
@@ -94,7 +100,10 @@ func (s *Server) toolGetDeployments(ctx context.Context, args map[string]interfa
 
 func (s *Server) toolGetServices(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 
 	client, err := s.getClientForCluster(cluster)
 	if err != nil {
@@ -197,7 +206,10 @@ func (s *Server) toolGetNodes(ctx context.Context, args map[string]interface{}) 
 
 func (s *Server) toolGetEvents(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	limit := int64(50)
 	if v, ok := args["limit"].(float64); ok {
 		limit = int64(v)
@@ -243,7 +255,10 @@ func (s *Server) toolGetEvents(ctx context.Context, args map[string]interface{})
 
 func (s *Server) toolDescribePod(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	name, ok := args["name"].(string)
 	if !ok || name == "" {
 		return "Pod name is required", true
@@ -298,7 +313,10 @@ func (s *Server) toolDescribePod(ctx context.Context, args map[string]interface{
 
 func (s *Server) toolGetPodLogs(ctx context.Context, args map[string]interface{}) (string, bool) {
 	cluster, _ := args["cluster"].(string)
-	namespace, _ := args["namespace"].(string)
+	namespace, err := extractAndValidateNamespace(args)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err), true
+	}
 	name, ok := args["name"].(string)
 	if !ok || name == "" {
 		return "Pod name is required", true


### PR DESCRIPTION
## Description

Added namespace validation to all MCP tools (kubestellar-ops + kubestellar-deploy) to prevent prompt injection attacks targeting system namespaces.

## Problem

MCP tools accept a `namespace` argument from the AI agent and pass it directly to the Kubernetes API without validation. A prompt injection attack could trick the AI into requesting `"namespace": "kube-system"`, giving access to system resources.

## Solution

Central `ValidateNamespace()` function using a blocklist approach:
- Exact blocked namespaces: `kube-system`, `kube-public`, `kube-node-lease`, `gatekeeper-system`, `openshift`
- Blocked prefix: `openshift-*` (covers all OpenShift system namespaces)
- All user namespaces continue to work (blocklist, not allowlist)
- Empty string (all-namespaces mode) is allowed
- Case-sensitive (matches Kubernetes behavior)

## Changes

**New files:**
- `pkg/mcp/server/namespace_validator.go` — central `ValidateNamespace()` + `extractAndValidateNamespace()`
- `pkg/mcp/server/namespace_validator_test.go` — 28 table-driven test cases
- `pkg/deploy/mcp/tools_namespace_test.go` — deploy server smoke tests

**kubestellar-ops (19 entry points, 4 files):**
- `tools_workloads.go` — getPods, getDeployments, getServices, getEvents, describePod, getPodLogs
- `tools_rbac.go` — getRoles, getRoleBindings, describeRole, findResourceOwners, canI, analyzeSubjectPermissions
- `diagnostics.go` — findPodIssues, findDeploymentIssues, checkResourceLimits, checkSecurityIssues, analyzeNamespace, getWarningEvents
- `tools_policy.go` — listOwnershipViolations

**kubestellar-deploy (17 entry points, 7 files):**
- `tools_helm.go` — helmInstall, helmUninstall, helmList, helmRollback
- `tools_kubectl.go` — deleteResource, kubectlApply (manifest-based)
- `tools_deploy.go` — deployApp (manifest-based), scaleApp, patchApp
- `tools_app.go` — getAppInstances, getAppStatus, getAppLogs, findAppInCluster, getLogsFromCluster
- `tools_labels.go` — addLabels, removeLabels
- `tools_gitops.go` — syncFromGit (namespace override)
- `tools_kustomize.go` — TODO added (kustomize builds non-structured YAML)

**Not validated (with TODO):** Kustomize tools — namespace is inside `kustomize build` YAML output, would require full manifest parsing. Left for a follow-up.

## Testing

- `go build ./...` — PASS
- `go vet ./...` — PASS
- `go test ./...` — PASS (28 new tests + all existing tests pass)

Fixes #377