### PR TITLE
[scanner] fix: pin mcp-publisher download with checksum verification

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -18,7 +18,16 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          VERSION="v1.7.9"
+          EXPECTED_SHA256="ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"
+          PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          TARBALL="mcp-publisher_${PLATFORM}_${ARCH}.tar.gz"
+          
+          curl -sL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${TARBALL}" -o "${TARBALL}"
+          echo "${EXPECTED_SHA256}  ${TARBALL}" | sha256sum -c -
+          tar xzf "${TARBALL}" mcp-publisher
+          rm "${TARBALL}"
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc


### PR DESCRIPTION
Fixes #391

Pins the `mcp-publisher` binary download in `publish-mcp-registry.yml` to a specific version (v1.7.9) with SHA256 checksum verification to mitigate supply-chain attacks.

## Changes
- Pinned `mcp-publisher` to v1.7.9 instead of "latest"
- Added SHA256 checksum verification before execution
- Downloads to a temporary file and verifies before extraction

## Security Impact
This addresses the security vulnerability where:
- The workflow downloaded an unpinned "latest" binary
- No checksum verification was performed
- The binary runs with `id-token: write` permission for OIDC authentication

A compromised binary could have:
- Published malicious MCP server definitions
- Exfiltrated the GitHub OIDC token
- Pivoted to other systems trusting the OIDC identity