### PR TITLE
[scanner] fix: disable pr-verifier calling non-existent reusable workflow

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -1,8 +1,8 @@
+# Disabled because kubestellar/infra/.github/workflows/reusable-pr-verifier.yml does not exist.
 name: PR Verifier
 
 on:
-  pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+  workflow_dispatch: {}
 
 permissions:
   checks: write


### PR DESCRIPTION
Fixes #394

The reusable workflow kubestellar/infra/.github/workflows/reusable-pr-verifier.yml does not exist. Disabling until it is created.