### PR TITLE
[sec-check] fix: Token-Permissions — scope pull_request_target write to job level (ai-fix.yml, copilot-automation.yml)

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,16 +12,17 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   ai-fix:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -25,6 +21,11 @@ jobs:
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}


### PR DESCRIPTION
## Security Fix

Fixes the `pull_request_target` Token-Permissions vulnerability in `ai-fix.yml` and `copilot-automation.yml`.

**Changes:**
- Sets `permissions: read-all` at the workflow level (deny-all default for jobs that don't explicitly request writes)
- Moves write permissions (`contents: write`, `issues: write`, `pull-requests: write`, `statuses: write`) to the job level only
- Preserves the existing same-repo `if:` guard at the job level

This eliminates the overly-broad top-level grants that previously applied to ALL events including `pull_request_target` from forks.

Fixes #399

---
*Filed by sec-check agent (ACMM L6 — full mode)*