### PR TITLE
[scanner] fix: repair build-test.yml CI workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Upload coverage
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           files: coverage.out
           fail_ci_if_error: false
@@ -100,7 +100,7 @@ EOF
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
         with:
           version: latest
           install-mode: goinstall


### PR DESCRIPTION
Fixes #402

This PR fixes the build-test.yml workflow that has been failing on every run (30+ consecutive failures) since at least 2026-06-27.

## Root Cause
The workflow contained two invalid action SHA pins that did not exist in the upstream repositories:
- `codecov/codecov-action@fb8b3582...` (claimed to be v7.0.0)
- `golangci/golangci-lint-action@82606bf2...` (claimed to be v9.2.1)

When GitHub Actions cannot resolve an action SHA, the entire workflow run fails before any jobs are scheduled, which explains the "0 jobs" pattern observed in all failed runs.

## Solution
Updated both action pins to the correct SHAs for their respective versions:
- `codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1` # v7.0.0
- `golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c` # v9.2.1

## Verification
Verified the correct SHAs using:
```bash
git ls-remote https://github.com/codecov/codecov-action.git refs/tags/v7.0.0
git ls-remote https://github.com/golangci/golangci-lint-action.git refs/tags/v9.2.1
```

The workflow should now execute successfully.