### PR TITLE
[scanner] fix: pin reusable workflow refs to SHA

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   label:
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   assignment-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -17,5 +17,5 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   verify:
-    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   stale:
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit


### PR DESCRIPTION
Fixes #414

Pin 7 reusable workflow references from `kubestellar/infra` to commit SHA `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3` instead of mutable `@main` to prevent supply-chain attacks.

Affected files:
- `.github/workflows/greetings.yml`
- `.github/workflows/add-help-wanted.yml`
- `.github/workflows/assignment-helper.yml`
- `.github/workflows/label-helper.yml`
- `.github/workflows/feedback.yml`
- `.github/workflows/stale.yml`
- `.github/workflows/pr-verifier.yml`