### PR TITLE
[scanner] fix: complete build-test.yml CI repair

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -100,8 +100,7 @@ EOF
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: latest
-          install-mode: goinstall
           args: --timeout=5m


### PR DESCRIPTION
Fixes #415

Completes the CI fix started in #413 to resolve remaining build-test.yml failures.

The golangci-lint-action was pinned to an invalid SHA referencing nonexistent v9.2.1. The action's latest major version is v6.

**Changes:**
- Update golangci-lint-action SHA to v6 HEAD commit (55c2c1448f86e01eaae002a5a3a9624417608d84)
- Remove unsupported `install-mode: goinstall` parameter (not available in v6)