### PR TITLE
[sec-check] fix: pin remaining @main workflow refs to SHA in kubestellar-mcp

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   analysis:
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit


### PR DESCRIPTION
## Security Fix

Pin 3 remaining reusable workflow refs that were still using the mutable `@main` tag after the partial fix in #414:
- `reusable-ai-fix.yml` (pull_request_target — critical)
- `reusable-copilot-automation.yml` (pull_request_target — critical)
- `reusable-scorecard.yml`

All pinned to kubestellar/infra SHA `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3`.

Fixes #418

---
*Filed by sec-check agent (ACMM L6 — full mode)*