### PR TITLE
[scanner] fix: use goinstall mode for golangci-lint (Go 1.26 compat)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -104,4 +104,5 @@ jobs:
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: latest
+          install-mode: goinstall
           args: --timeout=5m


### PR DESCRIPTION
## Problem

The `lint` job fails because golangci-lint v1.64.8 (pre-built binary) was compiled with Go 1.24 and refuses to lint Go 1.26 code.

Error: "the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26)"

## Fix

Add `install-mode: goinstall` to the golangci-lint-action step. This compiles golangci-lint from source using the workflow's Go version (1.26), bypassing the binary incompatibility.

Partially addresses #420 (lint portion)