### PR TITLE
[ci-maintainer] fix: add go mod tidy before CodeQL build step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,9 @@ jobs:
           languages: go
           queries: security-and-quality
 
+      - name: Tidy modules
+        run: go mod tidy
+
       - name: Build
         run: go build -v ./...
 


### PR DESCRIPTION
## CI Fix

`codeql.yml` was running `go build -v ./...` without first running `go mod tidy`. When `go.mod` declares `go 1.26` and the runner installs Go 1.26.x (any patch), Go's build system in `-mod=readonly` mode exits with:

```
go: updates to go.mod needed; to update it:
	go mod tidy
```

This caused **9 consecutive CodeQL failures** (runs #219–#227). Adding `go mod tidy` before `go build` ensures go.mod is consistent with the installed toolchain before CodeQL tracing begins.

Fixes #426

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*