### PR TITLE
[scanner] fix: update go.mod go directive for release workflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubestellar/kubestellar-mcp
 
-go 1.26
+go 1.26.0
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
Fixes #430

Run `go mod tidy` to update go directive from `1.26` to `1.26.0`, resolving CI test failures in the `release.yml` workflow.

The nightly release workflow was failing with error:
```
go: updates to go.mod needed; to update it: go mod tidy
```

This PR applies the required fix.