### PR TITLE
[scanner] fix: add top-level permissions to pr-verifier.yml

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,11 +4,12 @@ name: PR Verifier
 on:
   workflow_dispatch: {}
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: read-all
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # pinned from main
     secrets: inherit


### PR DESCRIPTION
Fixes #432

Adds explicit top-level `permissions: read-all` block and scopes specific permissions to the job level to satisfy OpenSSF Scorecard TokenPermissions check.