### PR TITLE
[ci-maintainer] fix: remove invalid bare 'read-all' from permissions blocks

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -5,7 +5,6 @@ on:
     types: [labeled]
 
 permissions:
-  read-all
   issues: write
 
 jobs:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -5,7 +5,6 @@ on:
     types: [created]
 
 permissions:
-  read-all
   issues: write
 
 jobs:

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -5,7 +5,6 @@ on:
     types: [closed]
 
 permissions:
-  read-all
   contents: read
   pull-requests: write
 

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -5,7 +5,6 @@ on:
     types: [created]
 
 permissions:
-  read-all
   contents: read
   issues: write
   pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  read-all
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary
- remove the invalid bare `read-all` line from workflow `permissions` blocks
- keep the remaining explicit permissions unchanged
- fix YAML parsing for the affected workflows

## Why
These workflow files currently define `permissions` as invalid YAML by mixing mapping entries with a bare `read-all` line. That breaks workflow parsing and leads to failed Actions runs.

Fixes #437