### PR TITLE
[scanner] fix: repair golangci-lint binary install + align CodeQL action versions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -107,5 +107,5 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v1.64.8
-          install-mode: goinstall
+          install-mode: binary
           args: --timeout=5m

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: go
           queries: security-and-quality


### PR DESCRIPTION
## Fix

Resolves two CI failures on `main`:

1. **Build and Test lint job**: `golangci-lint-action` v9.3.0 uses the v2 module path (`github.com/golangci/golangci-lint/v2/cmd/golangci-lint`) when `install-mode: goinstall`, which is incompatible with golangci-lint v1.64.8. Changed to `install-mode: binary` to download from GitHub Releases.

2. **CodeQL Analysis**: `codeql-action/init` was at v4.36.2 while `codeql-action/analyze` was already bumped to v4.36.3. Aligned both to v4.36.3.

Signed-off-by: kubestellar-hive[bot] <kubestellar-hive[bot]@users.noreply.github.com>