### PR TITLE
[ci-maintainer] fix: upgrade golangci-lint to v2.1.6 for golangci-lint-action v9 compatibility

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -106,6 +106,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v1.64.8
-          install-mode: binary
+          version: v2.1.6
           args: --timeout=5m

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -106,5 +106,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.1.6
+          version: v2.12.2
           args: --timeout=5m


### PR DESCRIPTION
## CI Fix

The `lint` job in `Build and Test` has been failing since Dependabot bumped `golangci-lint-action` from v6.5.2 to v9.3.0 (#441).

**Root cause:** `golangci-lint-action >= v7` dropped support for golangci-lint v1.x. The workflow specified `version: v1.64.8` (v1 release), triggering:
```
invalid version string 'v1.64.8', golangci-lint v1 is not supported by golangci-lint-action >= v7.
```

**Fix:** Update `version` to `v2.1.6` (current stable golangci-lint v2) and remove `install-mode: binary` (redundant — v9 action defaults to binary download).

**Evidence:** 3 lint failures on main today (runs 28791341258, 28791319964, 28787687342).

Fixes #447

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*

Labels: ci