### PR TITLE
[scanner] fix: resolve golangci-lint failures

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -106,6 +106,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v1.64.8
-          install-mode: binary
+          version: v2.1.6
           args: --timeout=5m


### PR DESCRIPTION
Fixes #447

Upgrade golangci-lint from v1.64.8 to v2.1.6 to fix incompatibility with golangci-lint-action >= v7 which dropped v1.x support. Remove install-mode: binary as v9 action handles binary install by default.