### PR TITLE
[scanner] fix: add fork guards to CI workflows

### DIFF
--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   copilot-automation:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,5 +13,6 @@ permissions:
 
 jobs:
   greet:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main as of 2026-07-07
     secrets: inherit


### PR DESCRIPTION
Fixes #476, Fixes #477

Added fork guard conditions to both workflows:
- `copilot-automation.yml`: Added job-level `if` condition to prevent execution on `pull_request_target` from forked repos
- `greetings.yml`: Added job-level `if` condition to prevent execution on `pull_request_target` from forked repos

Condition: `github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository`

This allows:
- All events that are not `pull_request_target` (e.g., `issues`, `workflow_dispatch`)
- Only `pull_request_target` events from the same repository (not forked PRs)