### PR TITLE
[scanner] fix: restrict workflow to minimum permissions

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -13,12 +13,14 @@ on:
     types: [opened]
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request_target'
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main as of 2026-07-07
     with:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -11,9 +11,7 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 permissions:
-  pull-requests: write
-  issues: write
-  statuses: write
+  contents: read
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -21,6 +19,10 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      pull-requests: write
+      issues: write
+      statuses: write
     if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # main pinned 2026-07-08
     with:


### PR DESCRIPTION
Fixes #480

Restricts top-level write permissions in ai-fix.yml and copilot-automation.yml to job-level, scoping permissions to the minimum required for each job. This mitigates TokenPermissions CWE-732 alerts #65 and #29 by preventing malicious PRs from inheriting unnecessary write permissions when triggering workflows via pull_request_target events.