### PR TITLE
[scanner] fix: resolve Copilot PR Automation startup_failure

### DIFF
--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   copilot-automation:
     permissions:
+      contents: write
       pull-requests: write
       issues: write
       statuses: write


### PR DESCRIPTION
Fixes #482

## Problem
Reusable workflow `reusable-copilot-automation.yml` requires `contents: write` permission, but caller only granted `contents: read` at workflow level. Job-level permissions inherited restricted permission, causing startup_failure.

## Solution
Added `contents: write` to job permissions to match reusable workflow requirements.