### PR TITLE
docs: add OpenCode integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,48 @@ Add the following to your project's `opencode.json` or `opencode.jsonc`:
 
 After adding, run `opencode mcp list` and verify both servers show as connected.
 
+> **For your AI agent** — Copy and paste this message into your OpenCode session to have it configure the MCP tools automatically:
+>
+> ```
+> Install kubestellar-ops and kubestellar-deploy:
+>
+>   # macOS — Homebrew
+>   brew tap kubestellar/tap
+>   brew install kubestellar-ops kubestellar-deploy
+>
+>   # Linux — download from GitHub Releases
+>   curl -LO https://github.com/kubestellar/kubestellar-mcp/releases/latest/download/kubestellar-ops_linux_amd64.tar.gz
+>   curl -LO https://github.com/kubestellar/kubestellar-mcp/releases/latest/download/kubestellar-deploy_linux_amd64.tar.gz
+>   tar xzf kubestellar-ops_linux_amd64.tar.gz
+>   tar xzf kubestellar-deploy_linux_amd64.tar.gz
+>   sudo mv kubestellar-ops kubestellar-deploy /usr/local/bin/
+>
+>   # Or build from source (any OS, requires Go 1.26+)
+>   git clone https://github.com/kubestellar/kubestellar-mcp.git
+>   cd kubestellar-mcp
+>   go build -o /usr/local/bin/kubestellar-ops ./cmd/kubestellar-ops
+>   go build -o /usr/local/bin/kubestellar-deploy ./cmd/kubestellar-deploy
+>
+> Then create opencode.jsonc in the project root with:
+>   {
+>     "$schema": "https://opencode.ai/config.json",
+>     "mcp": {
+>       "kubestellar-ops": {
+>         "type": "local",
+>         "command": ["kubestellar-ops", "--mcp-server"],
+>         "enabled": true
+>       },
+>       "kubestellar-deploy": {
+>         "type": "local",
+>         "command": ["kubestellar-deploy", "--mcp-server"],
+>         "enabled": true
+>       }
+>     }
+>   }
+>
+> Verify with: opencode mcp list
+> ```
+
 ### Generic MCP Client (stdio)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -172,6 +172,31 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
+### OpenCode
+
+[OpenCode](https://opencode.ai) is an open-source AI coding agent.
+Add the following to your project's `opencode.json` or `opencode.jsonc`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "kubestellar-ops": {
+      "type": "local",
+      "command": ["kubestellar-ops", "--mcp-server"],
+      "enabled": true
+    },
+    "kubestellar-deploy": {
+      "type": "local",
+      "command": ["kubestellar-deploy", "--mcp-server"],
+      "enabled": true
+    }
+  }
+}
+```
+
+After adding, run `opencode mcp list` and verify both servers show as connected.
+
 ### Generic MCP Client (stdio)
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -209,6 +209,31 @@ For write workflows, add `create`, `update`, `patch`, and `delete` to the resour
 /plugin marketplace add kubestellar/claude-plugins
 ```
 
+### OpenCode
+
+[OpenCode](https://opencode.ai) is an open-source AI coding agent.
+Add the following to your project's `opencode.json` or `opencode.jsonc`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "kubestellar-ops": {
+      "type": "local",
+      "command": ["kubestellar-ops", "--mcp-server"],
+      "enabled": true
+    },
+    "kubestellar-deploy": {
+      "type": "local",
+      "command": ["kubestellar-deploy", "--mcp-server"],
+      "enabled": true
+    }
+  }
+}
+```
+
+After adding, run `opencode mcp list` and verify both servers show as connected.
+
 ---
 
 ## kubestellar-ops

--- a/docs/index.md
+++ b/docs/index.md
@@ -234,6 +234,48 @@ Add the following to your project's `opencode.json` or `opencode.jsonc`:
 
 After adding, run `opencode mcp list` and verify both servers show as connected.
 
+> **For your AI agent** — Copy and paste this message into your OpenCode session to have it configure the MCP tools automatically:
+>
+> ```
+> Install kubestellar-ops and kubestellar-deploy:
+>
+>   # macOS — Homebrew
+>   brew tap kubestellar/tap
+>   brew install kubestellar-ops kubestellar-deploy
+>
+>   # Linux — download from GitHub Releases
+>   curl -LO https://github.com/kubestellar/kubestellar-mcp/releases/latest/download/kubestellar-ops_linux_amd64.tar.gz
+>   curl -LO https://github.com/kubestellar/kubestellar-mcp/releases/latest/download/kubestellar-deploy_linux_amd64.tar.gz
+>   tar xzf kubestellar-ops_linux_amd64.tar.gz
+>   tar xzf kubestellar-deploy_linux_amd64.tar.gz
+>   sudo mv kubestellar-ops kubestellar-deploy /usr/local/bin/
+>
+>   # Or build from source (any OS, requires Go 1.26+)
+>   git clone https://github.com/kubestellar/kubestellar-mcp.git
+>   cd kubestellar-mcp
+>   go build -o /usr/local/bin/kubestellar-ops ./cmd/kubestellar-ops
+>   go build -o /usr/local/bin/kubestellar-deploy ./cmd/kubestellar-deploy
+>
+> Then create opencode.jsonc in the project root with:
+>   {
+>     "$schema": "https://opencode.ai/config.json",
+>     "mcp": {
+>       "kubestellar-ops": {
+>         "type": "local",
+>         "command": ["kubestellar-ops", "--mcp-server"],
+>         "enabled": true
+>       },
+>       "kubestellar-deploy": {
+>         "type": "local",
+>         "command": ["kubestellar-deploy", "--mcp-server"],
+>         "enabled": true
+>       }
+>     }
+>   }
+>
+> Verify with: opencode mcp list
+> ```
+
 ---
 
 ## kubestellar-ops


### PR DESCRIPTION
## Description

Add documentation for using `kubestellar-mcp` with [OpenCode](https://opencode.ai), the open-source AI coding agent.

Both `kubestellar-ops` and `kubestellar-deploy` expose standard MCP tools over stdio (`--mcp-server`), which OpenCode supports natively via local MCP server configuration in `opencode.json` / `opencode.jsonc`.

**Changes:**
- `README.md`: Added OpenCode subsection under "Other AI Clients"
- `docs/index.md`: Added matching OpenCode subsection

**Testing performed:**
- Kind cluster deployed locally
- Both binaries built and MCP servers started
- `opencode mcp list` confirms both servers show as **connected**
- MCP protocol smoke test (raw JSON-RPC initialize) passed for both binaries

Closes #490