### PR TITLE
[sec-check] fix: enforce sensitive-kind and namespace validation in kustomize_apply/delete

### DIFF
--- a/pkg/deploy/mcp/tools_kubectl.go
+++ b/pkg/deploy/mcp/tools_kubectl.go
@@ -499,3 +499,27 @@ func parseYAML(data []byte, v interface{}) error {
 	}
 	return json.Unmarshal(jsonData, v)
 }
+
+// validateManifestDocs validates every --- separated document in a built manifest,
+// enforcing the same sensitive-kind and namespace rules used by the kubectl handlers.
+// Called by kustomize handlers before piping built output to kubectl apply/delete.
+func validateManifestDocs(manifest string) error {
+	for _, doc := range strings.Split(manifest, "---") {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+		if kind, blocked := manifestSensitiveKind(doc); blocked {
+			return sensitiveKindError(kind)
+		}
+		obj := &unstructured.Unstructured{}
+		if err := unstructuredFromYAML(doc, obj); err == nil {
+			if ns := obj.GetNamespace(); ns != "" {
+				if err := server.ValidateNamespace(ns); err != nil {
+					return fmt.Errorf("invalid namespace in manifest: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/deploy/mcp/tools_kustomize.go
+++ b/pkg/deploy/mcp/tools_kustomize.go
@@ -131,10 +131,6 @@ func (s *Server) handleKustomizeBuild(ctx context.Context, args json.RawMessage)
 	}, nil
 }
 
-// TODO(#377): Namespace validation for kustomize is deferred because namespace is
-// embedded in unstructured YAML output from `kustomize build`. Parsing the full
-// manifest to extract namespace(s) would require non-trivial YAML parsing.
-// Consider adding validation in a follow-up PR if needed.
 // handleKustomizeApply applies kustomize output to clusters
 func (s *Server) handleKustomizeApply(ctx context.Context, args json.RawMessage) (interface{}, error) {
 	var params struct {
@@ -168,6 +164,9 @@ func (s *Server) handleKustomizeApply(ctx context.Context, args json.RawMessage)
 
 	manifest, resourceCount, err := parseKustomizeBuildResult(buildResult)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateManifestDocs(manifest); err != nil {
 		return nil, err
 	}
 
@@ -244,7 +243,6 @@ func (s *Server) applyKustomize(ctx context.Context, cluster, path, manifest str
 	return result
 }
 
-// TODO(#377): Namespace validation for kustomize is deferred — see handleKustomizeApply.
 // handleKustomizeDelete deletes resources from kustomize output
 func (s *Server) handleKustomizeDelete(ctx context.Context, args json.RawMessage) (interface{}, error) {
 	var params struct {
@@ -278,6 +276,9 @@ func (s *Server) handleKustomizeDelete(ctx context.Context, args json.RawMessage
 
 	manifest, resourceCount, err := parseKustomizeBuildResult(buildResult)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateManifestDocs(manifest); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Security Fix

`handleKustomizeApply` and `handleKustomizeDelete` in `pkg/deploy/mcp/tools_kustomize.go` built Kustomize output and piped it directly to `kubectl apply`/`delete` without enforcing:

1. The sensitive-kind blocklist (Secrets, ClusterRoles, ClusterRoleBindings, ServiceAccounts) that `kubectl_apply` and `delete_resource` enforce
2. Namespace validation against blocked system namespaces (TODO #377 was never resolved)

This allowed a prompt-injected or malicious MCP caller to bypass all safety guards via the kustomize tools.

### Fix

Added `validateManifestDocs()` to `tools_kubectl.go` — it iterates every `---`-separated document in a built manifest, checks for blocked kinds via the existing `manifestSensitiveKind`/`sensitiveKindError` helpers, and validates namespaces via `server.ValidateNamespace`. Both `handleKustomizeApply` and `handleKustomizeDelete` now call it immediately after the `kustomize build` step, before any `kubectl` execution. Resolves TODO #377.

Fixes #489

---
*Filed by sec-check agent (ACMM L6 — full mode)*