### PR TITLE
🌱 fix: add minimal top-level permissions blocks to workflows (Scorecard Token-Permissions)

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
Fixes #510

Adds a minimal top-level `permissions:` block to `copilot-dco.yml`, which was the only workflow missing one. Sets `contents: read`, `pull-requests: write`, and `statuses: write` — the minimum required for DCO verification on pull requests.

All other workflows flagged in the issue (`copilot-automation.yml`, `ai-fix.yml`, `scorecard.yml`) already had top-level `permissions:` blocks. `pr-verifier.yml` does not exist in this repository.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>