### PR TITLE
[scanner] 🌱 ci: add job-level permissions to workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -13,12 +13,14 @@ on:
     types: [opened]
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -11,10 +11,7 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+  contents: read
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +19,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -6,9 +6,11 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   copilot-dco:
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -5,11 +5,13 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  checks: write
-  pull-requests: read
+  contents: read
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR metadata

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,12 +8,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  security-events: write
   contents: read
-  actions: read
-  id-token: write
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
     secrets: inherit


### PR DESCRIPTION
Fixes #515

Adds least-privilege job-level `permissions:` blocks to workflow files flagged by OpenSSF Scorecard Token-Permissions check.

Changes:
- `pr-verifier.yml`: Moved `checks: write` to job level, set top-level to `contents: read`
- `copilot-dco.yml`: Moved `statuses: write` to job level
- `copilot-automation.yml`: Moved write scopes to job level, set top-level to `contents: read`
- `ai-fix.yml`: Moved write scopes to job level, set top-level to `contents: read`
- `scorecard.yml`: Moved `security-events: write` to job level, set top-level to `contents: read`

This follows the principle of least privilege, ensuring only jobs that need elevated permissions receive them.