### PR TITLE
[scanner] fix: rename duplicate TestCleanupRemovesTempDirAndIsIdempotent

### DIFF
--- a/pkg/gitops/manifest_reader_pure_test.go
+++ b/pkg/gitops/manifest_reader_pure_test.go
@@ -190,7 +190,7 @@ func TestReadFromPathPropagatesReadFromFileErrors(t *testing.T) {
 	}
 }
 
-func TestCleanupRemovesTempDirAndIsIdempotent(t *testing.T) {
+func TestCleanupRemovesTempDirAndIsIdempotent_Pure(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "kubestellar-cleanup-*")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)


### PR DESCRIPTION
Fixes #523

Renames `TestCleanupRemovesTempDirAndIsIdempotent` in `pkg/gitops/manifest_reader_pure_test.go` to `TestCleanupRemovesTempDirAndIsIdempotent_Pure` to resolve the duplicate symbol introduced by PR #518 that is breaking the main branch build.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>