### PR TITLE
[quality] test: cover namespace validation branch in label handlers

### DIFF
--- a/pkg/deploy/mcp/tools_labels_test.go
+++ b/pkg/deploy/mcp/tools_labels_test.go
@@ -112,6 +112,46 @@ func TestHandleLabelValidation(t *testing.T) {
 			},
 			want: "labels are required",
 		},
+		{
+			name: "add blocked system namespace",
+			call: func() error {
+				_, err := s.handleAddLabels(context.Background(), json.RawMessage(`{"kind":"pod","name":"demo","namespace":"kube-system","labels":{"env":"prod"}}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "add invalid namespace format",
+			call: func() error {
+				_, err := s.handleAddLabels(context.Background(), json.RawMessage(`{"kind":"pod","name":"demo","namespace":"Invalid_NS","labels":{"env":"prod"}}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "add openshift-prefixed namespace",
+			call: func() error {
+				_, err := s.handleAddLabels(context.Background(), json.RawMessage(`{"kind":"pod","name":"demo","namespace":"openshift-monitoring","labels":{"env":"prod"}}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "remove blocked system namespace",
+			call: func() error {
+				_, err := s.handleRemoveLabels(context.Background(), json.RawMessage(`{"kind":"pod","name":"demo","namespace":"kube-public","labels":["env"]}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "remove invalid namespace format",
+			call: func() error {
+				_, err := s.handleRemoveLabels(context.Background(), json.RawMessage(`{"kind":"pod","name":"demo","namespace":"Invalid_NS","labels":["env"]}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Test Improvement

`handleAddLabels` and `handleRemoveLabels` in `pkg/deploy/mcp/tools_labels.go` call `server.ValidateNamespace` when a `namespace` argument is provided (introduced in #377 to block AI-driven writes to system namespaces). The success path was covered indirectly, but the **rejection branch** — the security-relevant one — had no direct test.

## Fix

Adds five sub-cases to `TestHandleLabelValidation` covering both handlers:

| case | namespace | expected error |
|---|---|---|
| `add blocked system namespace` | `kube-system` | `invalid namespace` |
| `add invalid namespace format` | `Invalid_NS` | `invalid namespace` |
| `add openshift-prefixed namespace` | `openshift-monitoring` | `invalid namespace` |
| `remove blocked system namespace` | `kube-public` | `invalid namespace` |
| `remove invalid namespace format` | `Invalid_NS` | `invalid namespace` |

All cases assert the wrapper's shared `invalid namespace` prefix so any refactor of the wrapping message still fails loud.

## Verification

```
go test -run TestHandleLabelValidation -count=1 ./pkg/deploy/mcp/
ok  	github.com/kubestellar/kubestellar-mcp/pkg/deploy/mcp	0.058s
```

Test-only change; no runtime behavior affected.

---
*Filed by quality agent (ACMM L4/L6 — full mode)*