### PR TITLE
[quality] test: cover namespace validation branch in helm handlers

### DIFF
--- a/pkg/deploy/mcp/tools_helm_namespace_test.go
+++ b/pkg/deploy/mcp/tools_helm_namespace_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestHandleHelmNamespaceValidation covers the security-relevant rejection
+// branch in the four helm handlers where server.ValidateNamespace is called
+// after arg parsing but before any cluster interaction (see #377). Each case
+// asserts the "invalid namespace" wrapper prefix so future refactors of the
+// wrapping message still fail loud.
+func TestHandleHelmNamespaceValidation(t *testing.T) {
+	s := &Server{}
+
+	cases := []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{
+			name: "install blocked system namespace",
+			call: func() error {
+				_, err := s.handleHelmInstall(context.Background(), json.RawMessage(`{"release_name":"demo","chart":"nginx","namespace":"kube-system"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "install openshift-prefixed namespace",
+			call: func() error {
+				_, err := s.handleHelmInstall(context.Background(), json.RawMessage(`{"release_name":"demo","chart":"nginx","namespace":"openshift-monitoring"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "install invalid namespace format",
+			call: func() error {
+				_, err := s.handleHelmInstall(context.Background(), json.RawMessage(`{"release_name":"demo","chart":"nginx","namespace":"Invalid_NS"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "uninstall blocked system namespace",
+			call: func() error {
+				_, err := s.handleHelmUninstall(context.Background(), json.RawMessage(`{"release_name":"demo","namespace":"kube-public"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "uninstall gatekeeper-system namespace",
+			call: func() error {
+				_, err := s.handleHelmUninstall(context.Background(), json.RawMessage(`{"release_name":"demo","namespace":"gatekeeper-system"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "list blocked system namespace",
+			call: func() error {
+				_, err := s.handleHelmList(context.Background(), json.RawMessage(`{"namespace":"kube-node-lease"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "list openshift-prefixed namespace",
+			call: func() error {
+				_, err := s.handleHelmList(context.Background(), json.RawMessage(`{"namespace":"openshift-logging"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "rollback blocked system namespace",
+			call: func() error {
+				_, err := s.handleHelmRollback(context.Background(), json.RawMessage(`{"release_name":"demo","namespace":"kube-system"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "rollback invalid namespace format",
+			call: func() error {
+				_, err := s.handleHelmRollback(context.Background(), json.RawMessage(`{"release_name":"demo","namespace":"Invalid_NS"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Test Improvement

`handleHelmInstall`, `handleHelmUninstall`, `handleHelmList`, and `handleHelmRollback` in `pkg/deploy/mcp/tools_helm.go` all call `server.ValidateNamespace` before touching any cluster (introduced in #377 to block AI-driven writes to system namespaces), but none of the four rejection branches had direct unit-test coverage. The follow-up to #525 (which covered the same gap in the label handlers) extends the same pattern to helm.

## Fix

Adds `TestHandleHelmNamespaceValidation` with 9 sub-cases across all four handlers:

| handler | case | namespace |
|---|---|---|
| install | blocked exact | `kube-system` |
| install | openshift prefix | `openshift-monitoring` |
| install | invalid RFC 1123 | `Invalid_NS` |
| uninstall | blocked exact | `kube-public` |
| uninstall | blocked exact | `gatekeeper-system` |
| list | blocked exact | `kube-node-lease` |
| list | openshift prefix | `openshift-logging` |
| rollback | blocked exact | `kube-system` |
| rollback | invalid RFC 1123 | `Invalid_NS` |

All cases assert the shared `invalid namespace` prefix from `tools_helm.go` so refactors of the wrapping message still fail loud.

## Verification

```
$ go test -run TestHandleHelmNamespaceValidation -count=1 -v ./pkg/deploy/mcp/
--- PASS: TestHandleHelmNamespaceValidation (0.00s)
    --- PASS: TestHandleHelmNamespaceValidation/install_blocked_system_namespace (0.00s)
    --- PASS: TestHandleHelmNamespaceValidation/install_openshift-prefixed_namespace (0.00s)
    --- PASS: TestHandleHelmNamespaceValidation/install_invalid_namespace_format (0.00s)
    --- PASS: TestHandleHelmNamespaceValidation/uninstall_blocked_system_namespace (0.00s)
    --- PASS: TestHandleHelmNamespaceValidation/uninstall_gatekeeper-system_namespace (0.00s)
    --- PASS: TestHandleHelmNamespaceValidation/list_blocked_system_namespace (0.00s)
    --- PASS: TestHandleHelmNamespaceValidation/list_openshift-prefixed_namespace (0.00s)
    --- PASS: TestHandleHelmNamespaceValidation/rollback_blocked_system_namespace (0.00s)
    --- PASS: TestHandleHelmNamespaceValidation/rollback_invalid_namespace_format (0.00s)
PASS
ok  	github.com/kubestellar/kubestellar-mcp/pkg/deploy/mcp	0.034s
```

Test-only change; no runtime behavior affected.

---
*Filed by quality agent (ACMM L4/L6 — full mode)*