### PR TITLE
[quality] test: cover namespace and app-name validation in app handlers

### DIFF
--- a/pkg/deploy/mcp/tools_app_namespace_test.go
+++ b/pkg/deploy/mcp/tools_app_namespace_test.go
@@ -1,0 +1,156 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestHandleAppNamespaceValidation covers the security-relevant rejection
+// branches in the three app handlers where the namespace argument is
+// checked by both claude.ValidateK8sNamespace (syntactic RFC 1123) and
+// server.ValidateNamespace (blocked-list, see #377). Both wrap the
+// underlying error as "invalid namespace" so a single assertion covers
+// both paths.
+func TestHandleAppNamespaceValidation(t *testing.T) {
+	s := &Server{}
+
+	cases := []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{
+			name: "instances blocked system namespace",
+			call: func() error {
+				_, err := s.handleGetAppInstances(context.Background(), json.RawMessage(`{"app":"demo","namespace":"kube-system"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "instances openshift-prefixed namespace",
+			call: func() error {
+				_, err := s.handleGetAppInstances(context.Background(), json.RawMessage(`{"app":"demo","namespace":"openshift-monitoring"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "instances invalid namespace format",
+			call: func() error {
+				_, err := s.handleGetAppInstances(context.Background(), json.RawMessage(`{"app":"demo","namespace":"Invalid_NS"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "status blocked system namespace",
+			call: func() error {
+				_, err := s.handleGetAppStatus(context.Background(), json.RawMessage(`{"app":"demo","namespace":"kube-public"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "status gatekeeper-system namespace",
+			call: func() error {
+				_, err := s.handleGetAppStatus(context.Background(), json.RawMessage(`{"app":"demo","namespace":"gatekeeper-system"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "logs blocked system namespace",
+			call: func() error {
+				_, err := s.handleGetAppLogs(context.Background(), json.RawMessage(`{"app":"demo","namespace":"kube-node-lease"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "logs openshift-prefixed namespace",
+			call: func() error {
+				_, err := s.handleGetAppLogs(context.Background(), json.RawMessage(`{"app":"demo","namespace":"openshift-logging"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "logs invalid namespace format",
+			call: func() error {
+				_, err := s.handleGetAppLogs(context.Background(), json.RawMessage(`{"app":"demo","namespace":"Invalid_NS"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandleAppInvalidAppName covers the validation branch for the App
+// argument itself, which every app handler validates first via
+// claude.ValidateK8sName. The three handlers wrap the error identically
+// as "invalid app name".
+func TestHandleAppInvalidAppName(t *testing.T) {
+	s := &Server{}
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "instances empty app",
+			call: func() error {
+				_, err := s.handleGetAppInstances(context.Background(), json.RawMessage(`{"app":""}`))
+				return err
+			},
+		},
+		{
+			name: "instances uppercase app",
+			call: func() error {
+				_, err := s.handleGetAppInstances(context.Background(), json.RawMessage(`{"app":"MyApp"}`))
+				return err
+			},
+		},
+		{
+			name: "status empty app",
+			call: func() error {
+				_, err := s.handleGetAppStatus(context.Background(), json.RawMessage(`{"app":""}`))
+				return err
+			},
+		},
+		{
+			name: "logs empty app",
+			call: func() error {
+				_, err := s.handleGetAppLogs(context.Background(), json.RawMessage(`{"app":""}`))
+				return err
+			},
+		},
+		{
+			name: "logs shell injection app",
+			call: func() error {
+				_, err := s.handleGetAppLogs(context.Background(), json.RawMessage(`{"app":"demo;rm -rf /"}`))
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil || !strings.Contains(err.Error(), "invalid app name") {
+				t.Fatalf("error = %v, want substring %q", err, "invalid app name")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Test Improvement

The three app handlers in `pkg/deploy/mcp/tools_app.go` (`handleGetAppInstances`, `handleGetAppStatus`, `handleGetAppLogs`) each run three input-validation checks before touching any cluster:

1. `claude.ValidateK8sName` on the required `app` field
2. `claude.ValidateK8sNamespace` on the namespace (syntactic RFC 1123)
3. `server.ValidateNamespace` on the namespace (system-ns blocklist, added in #377)

None of the three rejection branches had direct handler-level tests — `tools_app_test.go` only covers helper functions (`matchesApp`, `workloadStatusHelpers`, `replicasOrDefault`). This continues the pattern established in #525 (labels) and #526 (helm).

## Fix

Adds two new tests in `tools_app_namespace_test.go`:

**`TestHandleAppNamespaceValidation`** — 8 sub-cases across all three handlers:

| handler | namespace | expected |
|---|---|---|
| instances | `kube-system` | `invalid namespace` |
| instances | `openshift-monitoring` | `invalid namespace` |
| instances | `Invalid_NS` | `invalid namespace` |
| status | `kube-public` | `invalid namespace` |
| status | `gatekeeper-system` | `invalid namespace` |
| logs | `kube-node-lease` | `invalid namespace` |
| logs | `openshift-logging` | `invalid namespace` |
| logs | `Invalid_NS` | `invalid namespace` |

**`TestHandleAppInvalidAppName`** — 5 sub-cases covering empty app, uppercase, and shell-injection attempts across all three handlers.

## Verification

```
$ go test -run 'TestHandleApp' -count=1 -v ./pkg/deploy/mcp/
--- PASS: TestHandleAppNamespaceValidation (0.00s)
    ... 8 sub-cases PASS
--- PASS: TestHandleAppInvalidAppName (0.00s)
    ... 5 sub-cases PASS
PASS
ok  	github.com/kubestellar/kubestellar-mcp/pkg/deploy/mcp	0.034s
```

Test-only change; no runtime behavior affected.

---
*Filed by quality agent (ACMM L4/L6 — full mode)*