### PR TITLE
[quality] tests: cover gitops constructors and ReadFromGit validation

### DIFF
--- a/pkg/gitops/constructors_test.go
+++ b/pkg/gitops/constructors_test.go
@@ -1,0 +1,112 @@
+package gitops
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+// TestNewDriftDetector verifies the constructor returns a fully-wired
+// detector for a well-formed *rest.Config. Previously 0% covered.
+func TestNewDriftDetector(t *testing.T) {
+	dd, err := NewDriftDetector(&rest.Config{Host: "https://kube.example.invalid"})
+	if err != nil {
+		t.Fatalf("NewDriftDetector returned error: %v", err)
+	}
+	if dd == nil {
+		t.Fatal("NewDriftDetector returned nil detector")
+	}
+	if dd.client == nil {
+		t.Error("expected non-nil kubernetes clientset")
+	}
+	if dd.dynClient == nil {
+		t.Error("expected non-nil dynamic client")
+	}
+	// restMapper may be nil if discovery could not reach the cluster;
+	// newRESTMapper is documented to degrade gracefully.
+}
+
+// TestNewDriftDetector_InvalidConfig ensures an unusable rest.Config
+// surfaces an error rather than panicking.
+func TestNewDriftDetector_InvalidConfig(t *testing.T) {
+	// A config with an unparseable host triggers NewForConfig failure.
+	_, err := NewDriftDetector(&rest.Config{Host: "://not a url"})
+	if err == nil {
+		t.Fatal("expected error from malformed rest.Config, got nil")
+	}
+}
+
+// TestNewSyncer verifies the constructor returns a fully-wired syncer.
+// Previously 0% covered.
+func TestNewSyncer(t *testing.T) {
+	s, err := NewSyncer(&rest.Config{Host: "https://kube.example.invalid"})
+	if err != nil {
+		t.Fatalf("NewSyncer returned error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("NewSyncer returned nil syncer")
+	}
+	if s.dynClient == nil {
+		t.Error("expected non-nil dynamic client")
+	}
+}
+
+func TestNewSyncer_InvalidConfig(t *testing.T) {
+	_, err := NewSyncer(&rest.Config{Host: "://not a url"})
+	if err == nil {
+		t.Fatal("expected error from malformed rest.Config, got nil")
+	}
+}
+
+// TestNewRESTMapper_DegradesGracefully exercises the newRESTMapper fallback
+// path. When discovery cannot be reached, the function must return nil
+// (never panic) so callers fall back to static mapping. Previously 0% covered.
+func TestNewRESTMapper_DegradesGracefully(t *testing.T) {
+	// A malformed host makes discovery.NewDiscoveryClientForConfig fail;
+	// even if construction succeeds, GetAPIGroupResources will fail
+	// against a non-existent host. Either path returns nil.
+	m := newRESTMapper(&rest.Config{Host: "://malformed"})
+	if m != nil {
+		t.Errorf("expected nil RESTMapper on discovery failure, got %#v", m)
+	}
+}
+
+// TestReadFromGit_RejectsInvalidScheme confirms URL-scheme validation
+// runs before any git subprocess is spawned. Previously ReadFromGit was
+// 0% covered.
+func TestReadFromGit_RejectsInvalidScheme(t *testing.T) {
+	r := NewManifestReader()
+	_, err := r.ReadFromGit(context.Background(), ManifestSource{
+		Repo:   "file:///etc/passwd",
+		Branch: "main",
+	})
+	if err == nil {
+		t.Fatal("expected scheme validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "repo URL validation failed") {
+		t.Errorf("expected repo URL validation error, got: %v", err)
+	}
+}
+
+func TestReadFromGit_RejectsEmptyRepo(t *testing.T) {
+	r := NewManifestReader()
+	_, err := r.ReadFromGit(context.Background(), ManifestSource{Repo: ""})
+	if err == nil {
+		t.Fatal("expected error for empty repo, got nil")
+	}
+}
+
+func TestReadFromGit_RejectsInvalidBranch(t *testing.T) {
+	// Use custom schemes so URL validation passes and we exercise the
+	// branch-name validator before any subprocess launch.
+	r := NewManifestReaderWithSchemes(map[string]bool{"https": true})
+	_, err := r.ReadFromGit(context.Background(), ManifestSource{
+		Repo:   "https://example.invalid/repo.git",
+		Branch: "bad;branch$name", // contains characters outside [a-zA-Z0-9._/-]
+	})
+	if err == nil {
+		t.Fatal("expected branch validation error, got nil")
+	}
+}


### PR DESCRIPTION
## Test Improvement

Adds unit tests for previously **0%-covered** code paths in `pkg/gitops`.

### What's covered

| Symbol | File | Test |
|---|---|---|
| `NewDriftDetector` | `drift.go:49` | happy path + malformed `rest.Config` error |
| `NewSyncer` | `sync.go:57` | happy path + malformed `rest.Config` error |
| `newRESTMapper` | `resource_mapping.go:19` | graceful `nil` return on unreachable discovery |
| `(*ManifestReader).ReadFromGit` | `manifest.go:172` | rejects `file://` scheme, empty repo, invalid branch name — **before** any `git` subprocess is spawned |

All new tests are hermetic (no cluster, no network, no git process).

### Coverage

`pkg/gitops`: **75.2% → 81.8%** of statements.

### Local verification

```
$ go test -cover ./pkg/gitops/
ok  	github.com/kubestellar/kubestellar-mcp/pkg/gitops	0.095s	coverage: 81.8% of statements
```

Fixes #546

---
*Filed by quality agent (ACMM L4/L6 — full mode). Not merging this PR — a human or automerge agent will land it.*