### PR TITLE
fix: block system Namespace deletes via kubectl_delete

### DIFF
--- a/pkg/deploy/mcp/tools_kubectl.go
+++ b/pkg/deploy/mcp/tools_kubectl.go
@@ -51,6 +51,15 @@ func isSensitiveKind(kind string) bool {
 	return sensitiveKinds[strings.ToLower(kind)]
 }
 
+func isNamespaceKind(kind string) bool {
+	switch strings.ToLower(kind) {
+	case "namespace", "namespaces", "ns":
+		return true
+	default:
+		return false
+	}
+}
+
 func sensitiveKindError(kind string) error {
 	return fmt.Errorf("%q resources are blocked via MCP kubectl tools to prevent privilege escalation; use kubectl directly for this sensitive operation", kind)
 }
@@ -94,7 +103,13 @@ func (s *Server) handleDeleteResource(ctx context.Context, args json.RawMessage)
 	}
 
 	// Validate namespace to prevent access to system namespaces (#377).
-	if params.Namespace != "" {
+	// For kind Namespace the protected value is name (cluster-scoped), not the
+	// namespace field — otherwise deleting kube-system etc. would be allowed.
+	if isNamespaceKind(params.Kind) {
+		if err := server.ValidateNamespace(params.Name); err != nil {
+			return nil, fmt.Errorf("invalid namespace: %w", err)
+		}
+	} else if params.Namespace != "" {
 		if err := server.ValidateNamespace(params.Namespace); err != nil {
 			return nil, fmt.Errorf("invalid namespace: %w", err)
 		}
@@ -337,7 +352,13 @@ func (s *Server) applyManifestDynamic(ctx context.Context, clusterName, manifest
 		}
 
 		// Validate namespace from manifest to prevent access to system namespaces (#377).
-		if namespace != "" {
+		// For kind Namespace the protected value is metadata.name (cluster-scoped).
+		if isNamespaceKind(kind) {
+			if err := server.ValidateNamespace(name); err != nil {
+				return []ApplyResult{{Cluster: clusterName, Status: "failed",
+					Message: fmt.Sprintf("invalid namespace in manifest: %v", err)}}, nil
+			}
+		} else if namespace != "" {
 			if err := server.ValidateNamespace(namespace); err != nil {
 				return []ApplyResult{{Cluster: clusterName, Status: "failed",
 					Message: fmt.Sprintf("invalid namespace in manifest: %v", err)}}, nil
@@ -514,7 +535,11 @@ func validateManifestDocs(manifest string) error {
 		}
 		obj := &unstructured.Unstructured{}
 		if err := unstructuredFromYAML(doc, obj); err == nil {
-			if ns := obj.GetNamespace(); ns != "" {
+			if isNamespaceKind(obj.GetKind()) {
+				if err := server.ValidateNamespace(obj.GetName()); err != nil {
+					return fmt.Errorf("invalid namespace in manifest: %w", err)
+				}
+			} else if ns := obj.GetNamespace(); ns != "" {
 				if err := server.ValidateNamespace(ns); err != nil {
 					return fmt.Errorf("invalid namespace in manifest: %w", err)
 				}

--- a/pkg/deploy/mcp/tools_namespace_validation_rest_test.go
+++ b/pkg/deploy/mcp/tools_namespace_validation_rest_test.go
@@ -52,6 +52,32 @@ func TestHandleNamespaceValidationRemaining(t *testing.T) {
 			},
 			want: "invalid namespace",
 		},
+		// kind: Namespace is cluster-scoped — the protected value is
+		// name, not the namespace field (#kubectl_delete system NS).
+		{
+			name: "delete Namespace kind with blocked name kube-system",
+			call: func() error {
+				_, err := s.handleDeleteResource(context.Background(), json.RawMessage(`{"kind":"Namespace","name":"kube-system"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "delete ns kind with blocked name kube-public",
+			call: func() error {
+				_, err := s.handleDeleteResource(context.Background(), json.RawMessage(`{"kind":"ns","name":"kube-public"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
+		{
+			name: "delete namespaces kind with openshift-prefixed name",
+			call: func() error {
+				_, err := s.handleDeleteResource(context.Background(), json.RawMessage(`{"kind":"namespaces","name":"openshift-monitoring"}`))
+				return err
+			},
+			want: "invalid namespace",
+		},
 
 		// handleScaleApp — namespace check is the first non-parse
 		// gate, so simple JSON is sufficient to trigger it.
@@ -166,6 +192,16 @@ func TestValidateManifestDocs(t *testing.T) {
 			name:     "second doc with kube-public is rejected",
 			manifest: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: ok\n  namespace: default\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: bad\n  namespace: kube-public\n",
 			want:     "invalid namespace in manifest",
+		},
+		{
+			name:     "Namespace kind with blocked name kube-system is rejected",
+			manifest: "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: kube-system\n",
+			want:     "invalid namespace in manifest",
+		},
+		{
+			name:     "Namespace kind with allowed name passes",
+			manifest: "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: my-app\n",
+			want:     "",
 		},
 	}
 


### PR DESCRIPTION
### Description

Block deleting/applying system Namespaces. For `kind: Namespace`, validate `name` instead of the `namespace` field.

### Related Issue

Fixes #561 

### Changes Made

- [x] Validate Namespace `name` on delete, apply, and manifest checks
- [x] Added regression tests

### Checklist

- [x] Reviewed contribution guidelines
- [x] Added unit tests
- [ ] Updated docs (N/A)
- [x] Tested locally
- [x] Follows coding standards

### Additional Notes

User Namespaces (e.g. `my-app`) still work; only blocklisted names are rejected.