### PR TITLE
fix: block Secrets in add_labels and remove_labels

### DIFF
--- a/commands/label.md
+++ b/commands/label.md
@@ -27,9 +27,11 @@ Manage labels on resources across multiple clusters.
 ## Supported Resource Types
 
 - Deployments, StatefulSets, DaemonSets
-- Services, ConfigMaps, Secrets
+- Services, ConfigMaps
 - Pods, Namespaces, Nodes
 - PersistentVolumes, PersistentVolumeClaims
+
+Sensitive kinds (`Secret`, `ServiceAccount`, `ClusterRole`, `ClusterRoleBinding`) are blocked, matching `kubectl_apply` / `delete_resource`.
 
 ## Implementation
 

--- a/pkg/deploy/mcp/tools_labels.go
+++ b/pkg/deploy/mcp/tools_labels.go
@@ -43,6 +43,9 @@ func (s *Server) handleAddLabels(ctx context.Context, args json.RawMessage) (int
 	if len(params.Labels) == 0 {
 		return nil, fmt.Errorf("labels are required")
 	}
+	if isSensitiveKind(params.Kind) {
+		return nil, sensitiveKindError(params.Kind)
+	}
 
 	// Validate namespace to prevent access to system namespaces (#377).
 	if params.Namespace != "" {
@@ -109,6 +112,12 @@ func (s *Server) addLabelsInCluster(ctx context.Context, client *kubernetes.Clie
 		Labels:    labels,
 	}
 
+	if isSensitiveKind(kind) {
+		result.Status = "failed"
+		result.Message = sensitiveKindError(kind).Error()
+		return result, nil
+	}
+
 	if dryRun {
 		result.Status = "would-label"
 		result.Message = fmt.Sprintf("Would add labels to %s/%s", kind, name)
@@ -131,8 +140,6 @@ func (s *Server) addLabelsInCluster(ctx context.Context, client *kubernetes.Clie
 		_, err = client.CoreV1().Services(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
 	case "configmap", "configmaps", "cm":
 		_, err = client.CoreV1().ConfigMaps(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
-	case "secret", "secrets":
-		_, err = client.CoreV1().Secrets(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
 	case "pod", "pods":
 		_, err = client.CoreV1().Pods(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
 	case "statefulset", "statefulsets", "sts":
@@ -187,6 +194,9 @@ func (s *Server) handleRemoveLabels(ctx context.Context, args json.RawMessage) (
 	}
 	if len(params.Labels) == 0 {
 		return nil, fmt.Errorf("labels are required")
+	}
+	if isSensitiveKind(params.Kind) {
+		return nil, sensitiveKindError(params.Kind)
 	}
 
 	// Validate namespace to prevent access to system namespaces (#377).
@@ -253,6 +263,12 @@ func (s *Server) removeLabelsInCluster(ctx context.Context, client *kubernetes.C
 		Namespace: namespace,
 	}
 
+	if isSensitiveKind(kind) {
+		result.Status = "failed"
+		result.Message = sensitiveKindError(kind).Error()
+		return result, nil
+	}
+
 	if dryRun {
 		result.Status = "would-unlabel"
 		result.Message = fmt.Sprintf("Would remove labels %v from %s/%s", labelKeys, kind, name)
@@ -279,8 +295,6 @@ func (s *Server) removeLabelsInCluster(ctx context.Context, client *kubernetes.C
 		_, err = client.CoreV1().Services(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
 	case "configmap", "configmaps", "cm":
 		_, err = client.CoreV1().ConfigMaps(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
-	case "secret", "secrets":
-		_, err = client.CoreV1().Secrets(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
 	case "pod", "pods":
 		_, err = client.CoreV1().Pods(ns).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
 	case "statefulset", "statefulsets", "sts":

--- a/pkg/deploy/mcp/tools_labels_test.go
+++ b/pkg/deploy/mcp/tools_labels_test.go
@@ -152,6 +152,38 @@ func TestHandleLabelValidation(t *testing.T) {
 			},
 			want: "invalid namespace",
 		},
+		{
+			name: "add blocks Secret",
+			call: func() error {
+				_, err := s.handleAddLabels(context.Background(), json.RawMessage(`{"kind":"Secret","name":"creds","namespace":"default","labels":{"env":"prod"}}`))
+				return err
+			},
+			want: "blocked",
+		},
+		{
+			name: "add blocks secrets plural",
+			call: func() error {
+				_, err := s.handleAddLabels(context.Background(), json.RawMessage(`{"kind":"secrets","name":"creds","labels":{"env":"prod"}}`))
+				return err
+			},
+			want: "blocked",
+		},
+		{
+			name: "remove blocks Secret",
+			call: func() error {
+				_, err := s.handleRemoveLabels(context.Background(), json.RawMessage(`{"kind":"Secret","name":"creds","namespace":"default","labels":["env"]}`))
+				return err
+			},
+			want: "blocked",
+		},
+		{
+			name: "remove blocks ServiceAccount",
+			call: func() error {
+				_, err := s.handleRemoveLabels(context.Background(), json.RawMessage(`{"kind":"ServiceAccount","name":"default","namespace":"default","labels":["env"]}`))
+				return err
+			},
+			want: "blocked",
+		},
 	}
 
 	for _, tt := range tests {
@@ -161,6 +193,35 @@ func TestHandleLabelValidation(t *testing.T) {
 				t.Fatalf("error = %v, want substring %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestLabelOperationsBlockSensitiveKinds(t *testing.T) {
+	s := &Server{}
+
+	addResult, err := s.addLabelsInCluster(context.Background(), nil, "cluster-a", "Secret", "creds", "default", map[string]string{"env": "prod"}, false)
+	if err != nil {
+		t.Fatalf("addLabelsInCluster() unexpected error: %v", err)
+	}
+	if addResult.Status != "failed" || !strings.Contains(addResult.Message, "blocked") {
+		t.Fatalf("expected Secret add to be blocked, got %#v", addResult)
+	}
+
+	// Dry-run must not bypass the sensitive-kind policy.
+	dryAdd, err := s.addLabelsInCluster(context.Background(), nil, "cluster-a", "secrets", "creds", "default", map[string]string{"env": "prod"}, true)
+	if err != nil {
+		t.Fatalf("addLabelsInCluster() dry-run unexpected error: %v", err)
+	}
+	if dryAdd.Status != "failed" || !strings.Contains(dryAdd.Message, "blocked") {
+		t.Fatalf("expected dry-run Secret add to be blocked, got %#v", dryAdd)
+	}
+
+	removeResult, err := s.removeLabelsInCluster(context.Background(), nil, "cluster-a", "Secret", "creds", "default", []string{"env"}, false)
+	if err != nil {
+		t.Fatalf("removeLabelsInCluster() unexpected error: %v", err)
+	}
+	if removeResult.Status != "failed" || !strings.Contains(removeResult.Message, "blocked") {
+		t.Fatalf("expected Secret remove to be blocked, got %#v", removeResult)
 	}
 }
 


### PR DESCRIPTION
### Description

Block Secrets in `add_labels` / `remove_labels` the same way `kubectl_apply` does.

### Related Issue

Fixes #563

### Changes Made

- [x] Fixed sensitive-kind check on label tools
- [x] Added tests
- [x] Updated docs

### Checklist

- [x] Contribution guidelines reviewed
- [x] Unit tests added
- [x] Docs updated
- [x] Tested locally
- [x] Coding standards followed

### Screenshots or Logs (if applicable)

N/A

### Additional Notes

N/A